### PR TITLE
Add /arena command to show gym Pokémon levels by edition

### DIFF
--- a/PokeSoulLinkBot/Bot/Commands/ArenaCommand.cs
+++ b/PokeSoulLinkBot/Bot/Commands/ArenaCommand.cs
@@ -1,0 +1,65 @@
+using Discord;
+using Discord.WebSocket;
+using PokeSoulLinkBot.Bot.Helpers;
+
+namespace PokeSoulLinkBot.Bot.Commands;
+
+/// <summary>
+/// Handles the "arena" slash command.
+/// </summary>
+public sealed class ArenaCommand : ISlashCommand
+{
+    private static readonly IReadOnlyDictionary<string, IReadOnlyDictionary<int, IReadOnlyList<int>>> ArenaLevelsByEdition =
+        new Dictionary<string, IReadOnlyDictionary<int, IReadOnlyList<int>>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["ruby"] = new Dictionary<int, IReadOnlyList<int>>
+            {
+                [1] = new[] { 15, 14, 14 },
+                [2] = new[] { 19, 18, 17 },
+                [3] = new[] { 24, 22, 20, 20 },
+                [4] = new[] { 29, 26, 24, 24 },
+                [5] = new[] { 31, 29, 27, 27 },
+                [6] = new[] { 33, 31, 29, 29 },
+                [7] = new[] { 41, 41 },
+                [8] = new[] { 43, 42, 40, 40 },
+            },
+        };
+
+    /// <inheritdoc />
+    public string CommandName => "arena";
+
+    /// <inheritdoc />
+    public ApplicationCommandProperties BuildDefinition()
+    {
+        return new SlashCommandBuilder()
+            .WithName(this.CommandName)
+            .WithDescription("Zeigt die Level der Pokémon in einer Arena.")
+            .AddOption("edition", ApplicationCommandOptionType.String, "Die Edition (z. B. ruby).", isRequired: true)
+            .AddOption("number", ApplicationCommandOptionType.Integer, "Die Arena-Nummer (1-8).", isRequired: true)
+            .Build();
+    }
+
+    /// <inheritdoc />
+    public async Task HandleAsync(SocketSlashCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var edition = CommandOptionHelper.GetRequiredStringOption(command, "edition");
+        var arenaNumber = CommandOptionHelper.GetRequiredIntegerOption(command, "number");
+
+        if (!ArenaLevelsByEdition.TryGetValue(edition, out var arenaLevels))
+        {
+            await command.RespondAsync($"Für die Edition '{edition}' sind keine Arenadaten vorhanden.", ephemeral: true);
+            return;
+        }
+
+        if (!arenaLevels.TryGetValue(arenaNumber, out var levels))
+        {
+            await command.RespondAsync($"Für die Arena '{arenaNumber}' gibt es in '{edition}' keine Daten.", ephemeral: true);
+            return;
+        }
+
+        var joinedLevels = string.Join(", ", levels);
+        await command.RespondAsync($"In dieser Arena gibt es Pokemon auf dem Level: {joinedLevels}");
+    }
+}

--- a/PokeSoulLinkBot/Bot/Program.cs
+++ b/PokeSoulLinkBot/Bot/Program.cs
@@ -54,6 +54,7 @@ var commands = new List<ISlashCommand>
     new TeamCommand(runService, embedFactory, embedImageFactory),
     new UseCommand(runService, embedFactory, embedImageFactory),
     new PokedexCommand(pokedexService, pokedexPresenter),
+    new ArenaCommand(),
 };
 
 var slashCommandRouter = new SlashCommandRouter(commands, embedFactory);


### PR DESCRIPTION
### Motivation
- Provide a simple slash command to look up the Pokémon levels for a given gym/arena by edition and arena number so users can quickly query enemy levels during runs.

### Description
- Add new `ArenaCommand` implementing `ISlashCommand` in `PokeSoulLinkBot/Bot/Commands/ArenaCommand.cs` that exposes `/arena edition number` and returns a formatted level list.
- Add a lookup table with Ruby arena data (arenas 1–8) mapping arena numbers to lists of levels and format responses like `In dieser Arena gibt es Pokemon auf dem Level: 15, 14, 14`.
- Validate input and return ephemeral error messages when the edition or arena number is not found.
- Register the new command by adding `new ArenaCommand()` to the `commands` list in `PokeSoulLinkBot/Bot/Program.cs` so it is published on startup.

### Testing
- Attempted `dotnet build PokeSoulLinkBot/PokeSoulLinkBot.csproj`, but the build could not be executed in the environment because `dotnet` is not installed, so no successful compile/test run was performed.
- No project unit tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e11c17e9e08328a52af3bba5dc21f5)