### PR TITLE
Add route death command

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,9 +4,10 @@ Dieses Backlog sammelt fachliche und technische Aufgaben fuer die naechsten Iter
 
 ## Offen
 
-### Arena-Fortschritt im Run speichern
+### BL-001 Arena-Fortschritt im Run speichern
 
 - Status: offen
+- Branch: noch keiner
 - Ziel: Einen Command erstellen, mit dem festgehalten wird, dass eine Arena im laufenden Run erledigt ist.
 - Akzeptanzkriterien:
   - Der Command verwendet den aktiven Run der Discord-Guild.
@@ -14,9 +15,10 @@ Dieses Backlog sammelt fachliche und technische Aufgaben fuer die naechsten Iter
   - Der erledigte Arena-Status wird persistiert.
   - Status-, Stats- oder Run-Ausgaben koennen den Arena-Fortschritt anzeigen.
 
-### Einheitliche Command-Ausgaben
+### BL-002 Einheitliche Command-Ausgaben
 
 - Status: offen
+- Branch: noch keiner
 - Ziel: Den Output aller Commands normalisieren, damit Antworten ein einheitliches Bild haben und Daten uebersichtlich angezeigt werden.
 - Akzeptanzkriterien:
   - Einheitliche Embed- oder Textstruktur fuer Erfolg, Status, Fehler und Zusammenfassungen.
@@ -24,9 +26,10 @@ Dieses Backlog sammelt fachliche und technische Aufgaben fuer die naechsten Iter
   - Lange Listen bleiben lesbar und Discord-kompatibel.
   - Bestehende Tests werden angepasst oder ergaenzt.
 
-### DeathCommand um Reason und verursachenden Spieler erweitern
+### BL-003 DeathCommand um Reason und verursachenden Spieler erweitern
 
 - Status: offen
+- Branch: noch keiner
 - Ziel: Der DeathCommand bekommt eine Reason und optional einen Spieler, der Schuld war.
 - Akzeptanzkriterien:
   - `reason` ist als Command-Parameter verfuegbar.
@@ -34,20 +37,22 @@ Dieses Backlog sammelt fachliche und technische Aufgaben fuer die naechsten Iter
   - Reason und Spieler werden persistiert.
   - Ausgabe zeigt Route, betroffene Pokemon, Reason und optionalen Spieler.
 
-### Route direkt als verloren markieren
+### BL-004 Route direkt als verloren markieren
 
-- Status: offen
+- Status: erledigt
+- Branch: `codex/route-direkt-verloren`
 - Ziel: Einen leichten Command fuer Situationen erstellen, in denen eine Route direkt verloren ist, weil das erste Encounter-Pokemon nicht gefangen wurde.
 - Vorschlag: `/route-death`
 - Akzeptanzkriterien:
-  - Route kann direkt als tot/verloren markiert werden, ohne alle Pokemon einzeln zu erfassen.
-  - Reason ist verpflichtend oder sinnvoll vorbelegt.
-  - Optional kann angegeben werden, welcher Spieler das Encounter nicht gefangen hat.
-  - Der Command verhindert widerspruechliche Team-/Box-Zustaende.
+  - [x] Route kann direkt als tot/verloren markiert werden, ohne alle Pokemon einzeln zu erfassen.
+  - [x] Reason ist verpflichtend oder sinnvoll vorbelegt.
+  - [x] Optional kann angegeben werden, welcher Spieler das Encounter nicht gefangen hat.
+  - [x] Der Command verhindert widerspruechliche Team-/Box-Zustaende.
 
-### StatsCommand ausbauen
+### BL-005 StatsCommand ausbauen
 
 - Status: offen
+- Branch: noch keiner
 - Ziel: Den StatsCommand so implementieren, dass er basierend auf den gesammelten Daten weitere Statistiken ausgibt.
 - Moegliche Statistiken:
   - Anzahl gefangener, lebender und toter Routen.
@@ -60,9 +65,10 @@ Dieses Backlog sammelt fachliche und technische Aufgaben fuer die naechsten Iter
   - Leere oder neue Runs werden sauber behandelt.
   - Tests decken typische und leere Runs ab.
 
-### Workflow fuer Ticket-Bearbeitung definieren
+### BL-006 Workflow fuer Ticket-Bearbeitung definieren
 
 - Status: offen
+- Branch: noch keiner
 - Ziel: Einen klaren Workflow fuer das Bearbeiten von Tickets definieren.
 - Akzeptanzkriterien:
   - Ticket-Lifecycle ist beschrieben: Backlog, Analyse, Umsetzung, Tests, Review, Done.
@@ -70,9 +76,10 @@ Dieses Backlog sammelt fachliche und technische Aufgaben fuer die naechsten Iter
   - Erwartete Test- und Build-Kommandos sind dokumentiert.
   - Umgang mit StyleCop-Warnungen und Line-Endings ist beschrieben.
 
-### Build der Konsolen-App erstellen
+### BL-007 Build der Konsolen-App erstellen
 
 - Status: offen
+- Branch: noch keiner
 - Ziel: Einen Build der Konsolen-App bereitstellen, damit Visual Studio nicht vom Nutzer blockiert wird.
 - Akzeptanzkriterien:
   - Es gibt einen dokumentierten Build-/Publish-Befehl fuer die Konsolen-App.
@@ -80,9 +87,10 @@ Dieses Backlog sammelt fachliche und technische Aufgaben fuer die naechsten Iter
   - Startanleitung fuer den gebauten Bot ist dokumentiert.
   - Der Build enthaelt alle benoetigten Ressourcen und Konfigurationsdateien.
 
-### Game-Data-Katalog-Fetch beschleunigen und stabilisieren
+### BL-008 Game-Data-Katalog-Fetch beschleunigen und stabilisieren
 
 - Status: offen
+- Branch: noch keiner
 - Hintergrund: Der erste Fetch der PokeAPI Location Areas ist langsam, weil fuer viele Location Areas einzelne Detail-Requests ausgefuehrt werden.
 - Ziel: Startup und Autocomplete duerfen nicht davon abhaengen, dass alle Location Areas frisch geladen werden.
 - Akzeptanzkriterien:

--- a/PokeSoulLinkBot.Tests/CommandDefinitionTests.cs
+++ b/PokeSoulLinkBot.Tests/CommandDefinitionTests.cs
@@ -18,6 +18,7 @@ public sealed class CommandDefinitionTests
             { new CatchCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory(), new StubPokemonLookupService(), new StubGameDataCatalogService()), "catch", new[] { "route", "player", "pokemon" } },
             { new DeathCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory()), "death", new[] { "route" } },
             { new PokedexCommand(new StubPokedexService(), new PokedexPresenter()), "pokedex", new[] { "name" } },
+            { new RouteDeathCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory(), new StubGameDataCatalogService()), "route-death", new[] { "route", "reason", "player" } },
             { new RunEndCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory()), "run-end", new[] { "reason" } },
             { new RunStartCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory(), new StubGameDataCatalogService()), "run-start", new[] { "name", "edition", "player1", "player2", "player3" } },
             { new StatsCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory()), "stats", Array.Empty<string>() },
@@ -89,6 +90,16 @@ public sealed class CommandDefinitionTests
         }
 
         public LinkGroup RegisterDeath(string guildId, string pokemon)
+        {
+            throw new NotSupportedException();
+        }
+
+        public LinkGroup MarkRouteLost(
+            string guildId,
+            string route,
+            string? reason,
+            ulong? playerId,
+            string? playerName)
         {
             throw new NotSupportedException();
         }

--- a/PokeSoulLinkBot.Tests/RunServiceCatchTests.cs
+++ b/PokeSoulLinkBot.Tests/RunServiceCatchTests.cs
@@ -94,6 +94,71 @@ public sealed class RunServiceCatchTests
     }
 
     [Fact]
+    public void MarkRouteLost_ShouldCreateDeadRouteWithoutPokemon()
+    {
+        var store = new InMemoryRunStore();
+        var service = new RunService(store);
+        service.StartRun(GuildId, "Ruby", "ruby", CreatePlayers());
+
+        var linkGroup = service.MarkRouteLost(GuildId, "101", "Encounter fled.", 1, "marpie1");
+
+        Assert.Equal("101", linkGroup.Route);
+        Assert.Empty(linkGroup.Entries);
+        Assert.False(linkGroup.IsAlive);
+        Assert.True(linkGroup.IsLostWithoutEncounter);
+        Assert.Equal("Encounter fled.", linkGroup.LossReason);
+        Assert.Equal(1UL, linkGroup.FailedEncounterPlayerUserId);
+        Assert.Equal("marpie1", linkGroup.FailedEncounterPlayerName);
+        Assert.NotNull(linkGroup.LostAtUtc);
+        Assert.True(store.SaveCount > 0);
+    }
+
+    [Fact]
+    public void MarkRouteLost_ShouldUseDefaultReason()
+    {
+        var service = CreateServiceWithStartedRun();
+
+        var linkGroup = service.MarkRouteLost(GuildId, "101", null, null, null);
+
+        Assert.Equal("First encounter was not caught.", linkGroup.LossReason);
+    }
+
+    [Fact]
+    public void MarkRouteLost_ShouldRejectPlayerOutsideRun()
+    {
+        var service = CreateServiceWithStartedRun();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            service.MarkRouteLost(GuildId, "101", "Encounter fled.", 99, "outsider"));
+
+        Assert.Equal("The specified player is not part of the active run.", exception.Message);
+    }
+
+    [Fact]
+    public void MarkRouteLost_ShouldRejectRouteWithRegisteredCatches()
+    {
+        var service = CreateServiceWithStartedRun();
+        service.RegisterCatch(GuildId, "101", 1, "marpie1", "Bisasam", Array.Empty<string>());
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            service.MarkRouteLost(GuildId, "101", "Encounter fled.", null, null));
+
+        Assert.Equal("The route already has registered catches and must be marked dead with /death.", exception.Message);
+    }
+
+    [Fact]
+    public void MarkRouteLost_ShouldRejectAlreadyLostRoute()
+    {
+        var service = CreateServiceWithStartedRun();
+        service.MarkRouteLost(GuildId, "101", "Encounter fled.", null, null);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            service.MarkRouteLost(GuildId, "101", "Encounter fled again.", null, null));
+
+        Assert.Equal("The route has already been marked as lost.", exception.Message);
+    }
+
+    [Fact]
     public void TryAddToActive_ShouldAddGroupToFirstFreeTeamSlot()
     {
         var run = CreateRun();

--- a/PokeSoulLinkBot/Application/Interfaces/IRunService.cs
+++ b/PokeSoulLinkBot/Application/Interfaces/IRunService.cs
@@ -44,6 +44,22 @@ public interface IRunService
         IReadOnlyList<string> pokemonTypes);
 
     /// <summary>
+    /// Marks a route as lost before any Pokémon was caught there.
+    /// </summary>
+    /// <param name="guildId">The Discord guild identifier.</param>
+    /// <param name="route">The route or area name.</param>
+    /// <param name="reason">The reason why the encounter was lost.</param>
+    /// <param name="playerId">The optional Discord user identifier of the player who missed the encounter.</param>
+    /// <param name="playerName">The optional display name of the player who missed the encounter.</param>
+    /// <returns>The lost link group for the route.</returns>
+    LinkGroup MarkRouteLost(
+        string guildId,
+        string route,
+        string? reason,
+        ulong? playerId,
+        string? playerName);
+
+    /// <summary>
     /// Sets a route as active at the specified team position.
     /// </summary>
     /// <param name="guildId">The Discord guild identifier.</param>

--- a/PokeSoulLinkBot/Application/Services/RunService.cs
+++ b/PokeSoulLinkBot/Application/Services/RunService.cs
@@ -8,6 +8,8 @@ namespace PokeSoulLinkBot.Application.Services;
 /// </summary>
 public sealed class RunService : IRunService
 {
+    private const string DefaultRouteLossReason = "First encounter was not caught.";
+
     private readonly IRunStore runStore;
 
     /// <summary>
@@ -123,6 +125,55 @@ public sealed class RunService : IRunService
     }
 
     /// <inheritdoc />
+    public LinkGroup MarkRouteLost(
+        string guildId,
+        string route,
+        string? reason,
+        ulong? playerId,
+        string? playerName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(guildId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(route);
+
+        SoulLinkRun activeRun = this.GetActiveRun(guildId);
+        var normalizedRoute = this.NormalizeRoute(route);
+
+        if (playerId.HasValue && activeRun.Players.All(player => player.UserId != playerId.Value))
+        {
+            throw new InvalidOperationException("The specified player is not part of the active run.");
+        }
+
+        LinkGroup? existingGroup = activeRun.LinkGroups.FirstOrDefault(group =>
+            string.Equals(group.Route, normalizedRoute, StringComparison.OrdinalIgnoreCase));
+
+        if (existingGroup?.Entries.Count > 0)
+        {
+            throw new InvalidOperationException("The route already has registered catches and must be marked dead with /death.");
+        }
+
+        if (existingGroup?.IsLostWithoutEncounter == true)
+        {
+            throw new InvalidOperationException("The route has already been marked as lost.");
+        }
+
+        LinkGroup linkGroup = existingGroup ?? this.CreateLinkGroup(activeRun, normalizedRoute);
+        linkGroup.IsLostWithoutEncounter = true;
+        linkGroup.LossReason = string.IsNullOrWhiteSpace(reason)
+            ? DefaultRouteLossReason
+            : reason.Trim();
+        linkGroup.FailedEncounterPlayerUserId = playerId;
+        linkGroup.FailedEncounterPlayerName = string.IsNullOrWhiteSpace(playerName)
+            ? null
+            : playerName.Trim();
+        linkGroup.LostAtUtc = DateTime.UtcNow;
+
+        this.RemoveFromActiveLinks(activeRun, linkGroup);
+        this.runStore.Save();
+
+        return linkGroup;
+    }
+
+    /// <inheritdoc />
     public SoulLinkRun UseRoute(string guildId, string route, int position)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(guildId);
@@ -231,6 +282,19 @@ public sealed class RunService : IRunService
         run.LinkGroups.Add(linkGroup);
 
         return linkGroup;
+    }
+
+    private void RemoveFromActiveLinks(SoulLinkRun run, LinkGroup linkGroup)
+    {
+        for (var index = 0; index < run.ActiveLinks.Length; index++)
+        {
+            LinkGroup? activeLink = run.ActiveLinks[index];
+            if (activeLink != null &&
+                string.Equals(activeLink.Route, linkGroup.Route, StringComparison.OrdinalIgnoreCase))
+            {
+                run.ActiveLinks[index] = null;
+            }
+        }
     }
 
     private LinkGroup GetAliveLinkGroup(SoulLinkRun run, string route)

--- a/PokeSoulLinkBot/Bot/Commands/RouteDeathCommand.cs
+++ b/PokeSoulLinkBot/Bot/Commands/RouteDeathCommand.cs
@@ -1,0 +1,114 @@
+// <copyright file="RouteDeathCommand.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using Discord;
+using Discord.WebSocket;
+using PokeSoulLinkBot.Application.Interfaces;
+using PokeSoulLinkBot.Bot.Factories;
+using PokeSoulLinkBot.Bot.Helpers;
+using PokeSoulLinkBot.Core.Models;
+using Serilog;
+
+namespace PokeSoulLinkBot.Bot.Commands;
+
+/// <summary>
+/// Handles the "route-death" slash command.
+/// </summary>
+public sealed class RouteDeathCommand : ISlashCommand
+{
+    private readonly IRunService runService;
+    private readonly EmbedFactory embedFactory;
+    private readonly EmbedImageFactory embedImageFactory;
+    private readonly IGameDataCatalogService gameDataCatalogService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RouteDeathCommand"/> class.
+    /// </summary>
+    /// <param name="runService">The run service.</param>
+    /// <param name="embedFactory">The embed factory.</param>
+    /// <param name="embedImageFactory">The embed image factory.</param>
+    /// <param name="gameDataCatalogService">The game data catalog service.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when one of the parameters is <see langword="null"/>.
+    /// </exception>
+    public RouteDeathCommand(
+        IRunService runService,
+        EmbedFactory embedFactory,
+        EmbedImageFactory embedImageFactory,
+        IGameDataCatalogService gameDataCatalogService)
+    {
+        this.runService = runService ?? throw new ArgumentNullException(nameof(runService));
+        this.embedFactory = embedFactory ?? throw new ArgumentNullException(nameof(embedFactory));
+        this.embedImageFactory = embedImageFactory ?? throw new ArgumentNullException(nameof(embedImageFactory));
+        this.gameDataCatalogService = gameDataCatalogService ?? throw new ArgumentNullException(nameof(gameDataCatalogService));
+    }
+
+    /// <inheritdoc />
+    public string CommandName => "route-death";
+
+    /// <inheritdoc />
+    public ApplicationCommandProperties BuildDefinition()
+    {
+        return new SlashCommandBuilder()
+            .WithName(this.CommandName)
+            .WithDescription("Mark a route as lost because the first encounter was not caught.")
+            .AddOption("route", ApplicationCommandOptionType.String, "The route or area.", isRequired: true, isAutocomplete: true)
+            .AddOption("reason", ApplicationCommandOptionType.String, "Why the encounter was lost.", isRequired: false)
+            .AddOption("player", ApplicationCommandOptionType.User, "The player who missed the encounter.", isRequired: false)
+            .Build();
+    }
+
+    /// <inheritdoc />
+    public async Task HandleAsync(SocketSlashCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var guildId = CommandOptionHelper.GetGuildId(command);
+        var route = CommandOptionHelper.GetRequiredStringOption(command, "route");
+        var reason = CommandOptionHelper.GetOptionalStringOption(command, "reason");
+        var player = CommandOptionHelper.GetOptionalUserOption(command, "player");
+
+        var linkGroup = this.runService.MarkRouteLost(
+            guildId,
+            route,
+            reason,
+            player?.Id,
+            player?.Username);
+        var image = this.embedImageFactory.CreateDeathImage();
+        var embed = this.embedFactory.CreateRouteLostEmbed(linkGroup, image.AttachmentUrl);
+
+        await command.RespondWithFileAsync(image.FileAttachment, embed: embed);
+    }
+
+    /// <inheritdoc />
+    public async Task HandleAutocompleteAsync(SocketAutocompleteInteraction interaction)
+    {
+        ArgumentNullException.ThrowIfNull(interaction);
+
+        var guildId = interaction.GuildId?.ToString();
+        if (string.IsNullOrWhiteSpace(guildId))
+        {
+            Log.Warning("Route death autocomplete received without guild id.");
+            await interaction.RespondAsync(Array.Empty<AutocompleteResult>());
+            return;
+        }
+
+        var activeRun = this.runService.GetActiveRun(guildId);
+        var catalogRoutes = await this.gameDataCatalogService.GetRoutesAsync(activeRun.Game);
+        var existingRoutes = activeRun.LinkGroups.Select(group => group.Route);
+        var results = AutocompleteHelper.CreateResults(
+            catalogRoutes.Concat(existingRoutes),
+            AutocompleteHelper.GetCurrentValue(interaction));
+
+        Log.Debug(
+            "Route death autocomplete returned {ResultCount} route suggestions for edition '{Edition}' and value '{CurrentValue}'. CatalogRoutes={CatalogRouteCount}, ExistingRoutes={ExistingRouteCount}.",
+            results.Count,
+            activeRun.Game,
+            AutocompleteHelper.GetCurrentValue(interaction),
+            catalogRoutes.Count,
+            existingRoutes.Count());
+
+        await interaction.RespondAsync(results);
+    }
+}

--- a/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
+++ b/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
@@ -148,6 +148,38 @@ public sealed class EmbedFactory
     }
 
     /// <summary>
+    /// Creates an embed for a route lost before any catch was registered.
+    /// </summary>
+    /// <param name="linkGroup">The affected link group.</param>
+    /// <param name="imageUrl">The attachment URL of the image shown in the embed.</param>
+    /// <returns>The created embed.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="linkGroup"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="imageUrl"/> is null, empty, or whitespace.
+    /// </exception>
+    public Embed CreateRouteLostEmbed(LinkGroup linkGroup, string imageUrl)
+    {
+        ArgumentNullException.ThrowIfNull(linkGroup);
+        ArgumentException.ThrowIfNullOrWhiteSpace(imageUrl);
+
+        var builder = new EmbedBuilder()
+            .WithTitle("Route Lost")
+            .WithColor(new Color(128, 0, 128))
+            .WithDescription($"Route **{linkGroup.Route}** has been marked as lost.")
+            .AddField("Reason", linkGroup.LossReason ?? "First encounter was not caught.")
+            .WithImageUrl(imageUrl);
+
+        if (!string.IsNullOrWhiteSpace(linkGroup.FailedEncounterPlayerName))
+        {
+            builder.AddField("Player", linkGroup.FailedEncounterPlayerName, true);
+        }
+
+        return builder.Build();
+    }
+
+    /// <summary>
     /// Creates the status message for the active run.
     /// </summary>
     /// <param name="run">The active run.</param>

--- a/PokeSoulLinkBot/Bot/Helpers/CommandOptionHelper.cs
+++ b/PokeSoulLinkBot/Bot/Helpers/CommandOptionHelper.cs
@@ -1,6 +1,5 @@
 using Discord.WebSocket;
 using PokeSoulLinkBot.Core.Models;
-using System.Numerics;
 
 namespace PokeSoulLinkBot.Bot.Helpers;
 
@@ -100,6 +99,34 @@ public static class CommandOptionHelper
 
         var option = command.Data.Options.FirstOrDefault(x => x.Name == optionName)
             ?? throw new InvalidOperationException($"The option '{optionName}' is missing.");
+
+        if (option.Value is not SocketGuildUser user)
+        {
+            throw new InvalidOperationException($"The option '{optionName}' is not a valid guild user.");
+        }
+
+        return user;
+    }
+
+    /// <summary>
+    /// Gets an optional user option value.
+    /// </summary>
+    /// <param name="command">The slash command.</param>
+    /// <param name="optionName">The option name.</param>
+    /// <returns>The selected guild user if present; otherwise, <see langword="null"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the option value is not a guild user.
+    /// </exception>
+    public static SocketGuildUser? GetOptionalUserOption(SocketSlashCommand command, string optionName)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentException.ThrowIfNullOrWhiteSpace(optionName);
+
+        var option = command.Data.Options.FirstOrDefault(x => x.Name == optionName);
+        if (option is null)
+        {
+            return null;
+        }
 
         if (option.Value is not SocketGuildUser user)
         {

--- a/PokeSoulLinkBot/Bot/Program.cs
+++ b/PokeSoulLinkBot/Bot/Program.cs
@@ -64,6 +64,7 @@ var commands = new List<ISlashCommand>
     new RunEndCommand(runService, embedFactory, embedImageFactory),
     new CatchCommand(runService, embedFactory, embedImageFactory, pokemonLookupService, gameDataCatalogService),
     new DeathCommand(runService, embedFactory, embedImageFactory),
+    new RouteDeathCommand(runService, embedFactory, embedImageFactory, gameDataCatalogService),
     new StatusCommand(runService, embedFactory, embedImageFactory, pokemonLookupService),
     new StatsCommand(runService, embedFactory, embedImageFactory),
     new TeamCommand(runService, embedFactory, embedImageFactory),

--- a/PokeSoulLinkBot/Core/Models/LinkGroup.cs
+++ b/PokeSoulLinkBot/Core/Models/LinkGroup.cs
@@ -18,7 +18,32 @@ public sealed class LinkGroup
     /// <summary>
     /// Gets or sets the linked Pokémon entries for this group.
     /// </summary>
-    public List<LinkedPokemon> Entries { get; set; } = new();
+    public List<LinkedPokemon> Entries { get; set; } = new ();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this route was lost before a catch was registered.
+    /// </summary>
+    public bool IsLostWithoutEncounter { get; set; }
+
+    /// <summary>
+    /// Gets or sets the reason why this route was lost.
+    /// </summary>
+    public string? LossReason { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Discord user identifier of the player who missed the encounter.
+    /// </summary>
+    public ulong? FailedEncounterPlayerUserId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Discord user name of the player who missed the encounter.
+    /// </summary>
+    public string? FailedEncounterPlayerName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC date and time when this route was marked as lost.
+    /// </summary>
+    public DateTime? LostAtUtc { get; set; }
 
     /// <summary>
     ///     Gets a value indicating whether this link group is still alive (i.e., at least one linked Pokémon is alive).


### PR DESCRIPTION
## Zweck

Implementiert das Backlog-Ticket `BL-004 Route direkt als verloren markieren`.

## Aenderungen

- Neuer `/route-death` Slash-Command zum Markieren einer Route als verloren, ohne Pokemon einzeln zu erfassen.
- Persistiert Grund, optionalen verantwortlichen Spieler und Zeitpunkt am `LinkGroup`.
- Verhindert widerspruechliche Team-/Box-Zustaende, indem Routen mit registrierten Fangen fuer diesen Flow abgelehnt werden.
- Backlog mit stabilen IDs versehen und `BL-004` als erledigt markiert.
- Service- und Command-Definition-Tests ergaenzt.

## Verifikation

- `dotnet test PokeSoulLinkBot.Tests\PokeSoulLinkBot.Tests.csproj /p:UseAppHost=false`

Hinweis: Der Testlauf ist gruen, meldet aber bestehende StyleCop-Warnungen im Projekt, vor allem fehlende Datei-Header und bestehende SA1101/SA1516/SA1204-Warnungen.