### PR TITLE
[codex] Add backlog tickets for StyleCop and catch check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,14 @@ Diese Richtlinien gelten fuer alle Entwicklungsaufgaben in diesem Repository.
 
 - Vor Beginn eines Tickets wird geprueft, ob es bereits einen passenden Branch gibt. Falls nicht, wird von `main` aus ein neuer Feature-Branch erstellt und vorher der aktuelle Stand von `origin/main` geholt.
 - Aenderungen fuer ein Ticket bleiben auf dem zugehoerigen Branch. Nach Abschluss werden die relevanten Dateien geprueft, committed und auf den Branch gepusht.
+- Git-Befehle fuer den normalen Ticket-Workflow duerfen ohne Rueckfrage ausgefuehrt werden, insbesondere `git add`, `git commit`, `git switch` und `git push` ohne Force-Optionen. Force-Pushes, auch `--force-with-lease`, duerfen nur nach ausdruecklicher Zustimmung ausgefuehrt werden.
 - Falls fuer den Task noch kein Pull Request existiert, wird nach dem Push ein Pull Request erstellt.
 - StyleCop-Anmerkungen werden immer behoben. Neuer oder geaenderter Code soll keine StyleCop-Warnungen einfuehren.
 - Code wird mit Clean-Code-Prinzipien im Blick geschrieben: klare Namen, kleine fokussierte Einheiten, geringe Kopplung und gut lesbare Kontrollfluesse.
 - SOLID-Prinzipien werden beachtet. Abhaengigkeiten, Verantwortlichkeiten und Erweiterungspunkte sollen bewusst geschnitten sein.
 - Code soll getestet sein. Neue Logik bekommt passende Tests; bestehende Tests werden angepasst, wenn sich Verhalten bewusst aendert.
 - Vor einem Commit wird der Diff geprueft, insbesondere auf unbeabsichtigte Formatierungs-, Whitespace- oder Line-Ending-Aenderungen. Line Endings muessen dem im Repository gesetzten Standard entsprechen.
+- Manuelle Datei-Aenderungen werden direkt mit CRLF geschrieben oder unmittelbar nach dem Patch auf CRLF normalisiert. Vor dem Commit wird mit `git ls-files --eol` geprueft, dass geaenderte Textdateien nicht mit gemischten Line Endings im Worktree liegen.
 - Vor Abschluss einer Aufgabe werden relevante Formatierungs-, Analyse- und Testbefehle ausgefuehrt, soweit sie im Projekt verfuegbar und praktikabel sind.
 - Alle relevanten Tests muessen vor Abschluss gruen sein. Falls ein Test nicht ausgefuehrt werden kann, wird der Grund dokumentiert.
 - Bestehende Nutzer- oder Fremdaenderungen werden nicht ueberschrieben oder zurueckgesetzt, ausser dies wurde ausdruecklich beauftragt.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -99,3 +99,32 @@ Dieses Backlog sammelt fachliche und technische Aufgaben fuer die naechsten Iter
   - Location-Area-Details werden begrenzt parallelisiert oder anderweitig schneller geladen.
   - Bei API-Fehlern bleiben Edition-Autocomplete und bestehende Route-Daten nutzbar.
   - Optional: Ein vorbefuellter JSON-Katalog wird ins Repository aufgenommen.
+
+### BL-009 StyleCop-Dateikopf-Regel deaktivieren
+
+- Status: offen
+- Branch: noch keiner
+- Hintergrund: StyleCop meldet aktuell `The file header is missing or not located at the top of the file.`
+- Ziel: Die File-Header-Warnung wird in der StyleCop-Konfiguration deaktiviert, weil dieses Repository keine verpflichtenden Dateikoepfe verwendet.
+- Akzeptanzkriterien:
+  - Die betroffene StyleCop-Regel fuer fehlende Dateikoepfe ist zentral deaktiviert.
+  - Neue und bestehende Dateien muessen keinen File Header enthalten.
+  - StyleCop-Analyse oder Build laeuft ohne diese Warnung durch.
+  - Andere StyleCop-Regeln bleiben unveraendert aktiv.
+
+### BL-010 Command fuer Fangbarkeits-Check
+
+- Status: offen
+- Branch: noch keiner
+- Ziel: Einen Command erstellen, mit dem geprueft werden kann, ob ein Pokemon im aktiven Run noch gefangen werden darf.
+- Vorschlag: `/catch-check`
+- Akzeptanzkriterien:
+  - Der Command akzeptiert einen Pokemon-Namen auf Deutsch oder Englisch.
+  - Der Name wird auf eine eindeutige Pokemon-Spezies aufgeloest.
+  - Der Check betrachtet alle bereits gefangenen Pokemon des aktiven Runs, unabhaengig davon, ob sie leben oder tot sind.
+  - Fuer jedes bereits gefangene Pokemon wird auch dessen Evolutionslinie beruecksichtigt.
+  - Wenn das angefragte Pokemon selbst oder ein Pokemon derselben Evolutionslinie bereits im Run vorkommt, meldet der Command, dass es nicht gefangen werden darf.
+  - Wenn kein Treffer gefunden wird, meldet der Command, dass das Pokemon gefangen werden darf.
+  - Die Ausgabe nennt bei einem Treffer das passende bereits gefangene Pokemon inklusive Route, Spieler und Status, soweit vorhanden.
+  - Unbekannte oder mehrdeutige Pokemon-Namen werden mit einer klaren Fehlermeldung behandelt.
+  - Tests decken deutsche und englische Namen, lebende und tote Pokemon, Evolutionslinien und den erlaubten Fall ohne Treffer ab.


### PR DESCRIPTION
## Summary

- Add BL-009 for disabling the StyleCop file-header warning because the repository does not require file headers.
- Add BL-010 for a new catch-check command that resolves German or English Pokemon names and checks captured Pokemon plus their evolution lines.

## Validation

- `git diff --check`
- Reviewed the `BACKLOG.md` diff and normalized line endings to the repository CRLF setting.