### PR TITLE
[codex] Disable StyleCop file header rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,6 @@ root = true
 [*]
 end_of_line = crlf
 insert_final_newline = true
+
+[*.cs]
+dotnet_diagnostic.SA1633.severity = none

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -102,15 +102,15 @@ Dieses Backlog sammelt fachliche und technische Aufgaben fuer die naechsten Iter
 
 ### BL-009 StyleCop-Dateikopf-Regel deaktivieren
 
-- Status: offen
-- Branch: noch keiner
+- Status: erledigt
+- Branch: `codex/disable-stylecop-file-header`
 - Hintergrund: StyleCop meldet aktuell `The file header is missing or not located at the top of the file.`
 - Ziel: Die File-Header-Warnung wird in der StyleCop-Konfiguration deaktiviert, weil dieses Repository keine verpflichtenden Dateikoepfe verwendet.
 - Akzeptanzkriterien:
-  - Die betroffene StyleCop-Regel fuer fehlende Dateikoepfe ist zentral deaktiviert.
-  - Neue und bestehende Dateien muessen keinen File Header enthalten.
-  - StyleCop-Analyse oder Build laeuft ohne diese Warnung durch.
-  - Andere StyleCop-Regeln bleiben unveraendert aktiv.
+  - [x] Die betroffene StyleCop-Regel fuer fehlende Dateikoepfe ist zentral deaktiviert.
+  - [x] Neue und bestehende Dateien muessen keinen File Header enthalten.
+  - [x] StyleCop-Analyse oder Build laeuft ohne diese Warnung durch.
+  - [x] Andere StyleCop-Regeln bleiben unveraendert aktiv.
 
 ### BL-010 Command fuer Fangbarkeits-Check
 

--- a/PokeSoulLinkBot/Application/Services/PokeApiPokedexService.cs
+++ b/PokeSoulLinkBot/Application/Services/PokeApiPokedexService.cs
@@ -75,84 +75,6 @@ public sealed class PokeApiPokedexService : IPokedexService
         };
     }
 
-    private async Task AddEvolutionRowsAsync(
-        EvolutionChainLinkDto chainLink,
-        string requirementText,
-        List<PokedexTableRow> rows)
-    {
-        ArgumentNullException.ThrowIfNull(chainLink);
-        ArgumentNullException.ThrowIfNull(rows);
-
-        var pokemonName = chainLink.Species?.Name
-            ?? throw new InvalidOperationException("Evolution chain contains an invalid species entry.");
-
-        var pokemon = await this.GetPokemonAsync(pokemonName)
-            ?? throw new InvalidOperationException($"Pokémon '{pokemonName}' could not be loaded.");
-
-        rows.Add(new PokedexTableRow
-        {
-            PokemonName = FormatResourceName(pokemonName),
-            RequirementText = requirementText,
-            Types = GetFormattedTypes(pokemon),
-        });
-
-        if (chainLink.EvolvesTo is null || chainLink.EvolvesTo.Count == 0)
-        {
-            return;
-        }
-
-        foreach (var nextEvolution in chainLink.EvolvesTo)
-        {
-            var nextRequirement = FormatEvolutionRequirements(nextEvolution.EvolutionDetails);
-            await this.AddEvolutionRowsAsync(nextEvolution, nextRequirement, rows);
-        }
-    }
-
-    private async Task<PokemonDto?> GetPokemonAsync(string pokemonName)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(pokemonName);
-
-        var requestUri = $"pokemon/{Uri.EscapeDataString(NormalizePokemonName(pokemonName))}";
-        return await this.GetFromApiAsync<PokemonDto>(requestUri);
-    }
-
-    private async Task<PokemonSpeciesDto?> GetPokemonSpeciesAsync(string pokemonName)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(pokemonName);
-
-        var requestUri = $"pokemon-species/{Uri.EscapeDataString(NormalizePokemonName(pokemonName))}";
-        return await this.GetFromApiAsync<PokemonSpeciesDto>(requestUri);
-    }
-
-    private async Task<EvolutionChainDto?> GetEvolutionChainAsync(string requestUri)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(requestUri);
-
-        return await this.GetFromApiAsync<EvolutionChainDto>(requestUri);
-    }
-
-    private async Task<T?> GetFromApiAsync<T>(string requestUri)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(requestUri);
-
-        try
-        {
-            using var response = await this.httpClient.GetAsync(requestUri);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                return default;
-            }
-
-            await using var responseStream = await response.Content.ReadAsStreamAsync();
-            return await JsonSerializer.DeserializeAsync<T>(responseStream, JsonSerializerOptions);
-        }
-        catch (Exception exception) when (exception is HttpRequestException or JsonException or TaskCanceledException)
-        {
-            throw new InvalidOperationException($"PokéAPI request '{requestUri}' failed: {exception.Message}", exception);
-        }
-    }
-
     private static IReadOnlyList<string> GetFormattedTypes(PokemonDto pokemon)
     {
         ArgumentNullException.ThrowIfNull(pokemon);
@@ -354,5 +276,83 @@ public sealed class PokeApiPokedexService : IPokedexService
             ' ',
             value.Split('-', StringSplitOptions.RemoveEmptyEntries)
                 .Select(part => char.ToUpperInvariant(part[0]) + part[1..]));
+    }
+
+    private async Task AddEvolutionRowsAsync(
+        EvolutionChainLinkDto chainLink,
+        string requirementText,
+        List<PokedexTableRow> rows)
+    {
+        ArgumentNullException.ThrowIfNull(chainLink);
+        ArgumentNullException.ThrowIfNull(rows);
+
+        var pokemonName = chainLink.Species?.Name
+            ?? throw new InvalidOperationException("Evolution chain contains an invalid species entry.");
+
+        var pokemon = await this.GetPokemonAsync(pokemonName)
+            ?? throw new InvalidOperationException($"Pokémon '{pokemonName}' could not be loaded.");
+
+        rows.Add(new PokedexTableRow
+        {
+            PokemonName = FormatResourceName(pokemonName),
+            RequirementText = requirementText,
+            Types = GetFormattedTypes(pokemon),
+        });
+
+        if (chainLink.EvolvesTo is null || chainLink.EvolvesTo.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var nextEvolution in chainLink.EvolvesTo)
+        {
+            var nextRequirement = FormatEvolutionRequirements(nextEvolution.EvolutionDetails);
+            await this.AddEvolutionRowsAsync(nextEvolution, nextRequirement, rows);
+        }
+    }
+
+    private async Task<PokemonDto?> GetPokemonAsync(string pokemonName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pokemonName);
+
+        var requestUri = $"pokemon/{Uri.EscapeDataString(NormalizePokemonName(pokemonName))}";
+        return await this.GetFromApiAsync<PokemonDto>(requestUri);
+    }
+
+    private async Task<PokemonSpeciesDto?> GetPokemonSpeciesAsync(string pokemonName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pokemonName);
+
+        var requestUri = $"pokemon-species/{Uri.EscapeDataString(NormalizePokemonName(pokemonName))}";
+        return await this.GetFromApiAsync<PokemonSpeciesDto>(requestUri);
+    }
+
+    private async Task<EvolutionChainDto?> GetEvolutionChainAsync(string requestUri)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(requestUri);
+
+        return await this.GetFromApiAsync<EvolutionChainDto>(requestUri);
+    }
+
+    private async Task<T?> GetFromApiAsync<T>(string requestUri)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(requestUri);
+
+        try
+        {
+            using var response = await this.httpClient.GetAsync(requestUri);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return default;
+            }
+
+            await using var responseStream = await response.Content.ReadAsStreamAsync();
+            return await JsonSerializer.DeserializeAsync<T>(responseStream, JsonSerializerOptions);
+        }
+        catch (Exception exception) when (exception is HttpRequestException or JsonException or TaskCanceledException)
+        {
+            throw new InvalidOperationException($"PokéAPI request '{requestUri}' failed: {exception.Message}", exception);
+        }
     }
 }

--- a/PokeSoulLinkBot/Bot/Commands/DeathCommand.cs
+++ b/PokeSoulLinkBot/Bot/Commands/DeathCommand.cs
@@ -43,7 +43,7 @@ public class DeathCommand : ISlashCommand
     public ApplicationCommandProperties BuildDefinition()
     {
         return new SlashCommandBuilder()
-            .WithName(CommandName)
+            .WithName(this.CommandName)
             .WithDescription("Register the death of a linked Pokémon group.")
             .AddOption("route", ApplicationCommandOptionType.String, "The route that is now dead.", isRequired: true, isAutocomplete: true)
             .Build();

--- a/PokeSoulLinkBot/Bot/Commands/RouteDeathCommand.cs
+++ b/PokeSoulLinkBot/Bot/Commands/RouteDeathCommand.cs
@@ -1,7 +1,3 @@
-// <copyright file="RouteDeathCommand.cs" company="PlaceholderCompany">
-// Copyright (c) PlaceholderCompany. All rights reserved.
-// </copyright>
-
 using Discord;
 using Discord.WebSocket;
 using PokeSoulLinkBot.Application.Interfaces;

--- a/PokeSoulLinkBot/Bot/Commands/UseCommand.cs
+++ b/PokeSoulLinkBot/Bot/Commands/UseCommand.cs
@@ -42,7 +42,7 @@ public class UseCommand : ISlashCommand
     public ApplicationCommandProperties BuildDefinition()
     {
         return new SlashCommandBuilder()
-            .WithName(CommandName)
+            .WithName(this.CommandName)
             .WithDescription("Sets one route for every player as an active pokemon.")
             .AddOption("route", ApplicationCommandOptionType.String, "The number of the route to use.", isRequired: true)
             .AddOption("position", ApplicationCommandOptionType.Integer, "The position in the active team [1 - 6].", isRequired: true)

--- a/PokeSoulLinkBot/Core/Models/PokedexEntry.cs
+++ b/PokeSoulLinkBot/Core/Models/PokedexEntry.cs
@@ -18,5 +18,5 @@ public sealed class PokedexEntry
     /// <summary>
     /// Gets or sets the rows shown in the evolution table.
     /// </summary>
-    public List<PokedexTableRow> Rows { get; set; } = new();
+    public List<PokedexTableRow> Rows { get; set; } = new ();
 }

--- a/PokeSoulLinkBot/Core/Models/PokemonNameEntry.cs
+++ b/PokeSoulLinkBot/Core/Models/PokemonNameEntry.cs
@@ -9,5 +9,6 @@ namespace PokeSoulLinkBot.Core.Models;
 public sealed class PokemonNameEntry
 {
     public string EnglishName { get; set; } = string.Empty;
+
     public string GermanName { get; set; } = string.Empty;
 }

--- a/PokeSoulLinkBot/GlobalSuppressions.cs
+++ b/PokeSoulLinkBot/GlobalSuppressions.cs
@@ -5,7 +5,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1633:File should have header", Justification = "<Ausstehend>", Scope = "namespace", Target = "~N:PokeSoulLinkBot.Core.Models")]
-[assembly: SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1101:Prefix local calls with this", Justification = "<Ausstehend>", Scope = "member", Target = "~M:PokeSoulLinkBot.Infrastructure.Persistence.RunStore.#ctor(System.String)")]
 [assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1200:Using directives should be placed correctly", Justification = "<Ausstehend>")]
+
 [assembly: SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1101:Prefix local calls with this", Justification = "<Ausstehend>", Scope = "member", Target = "~M:PokeSoulLinkBot.Core.Models.SoulLinkRun.TryAddToActive(PokeSoulLinkBot.Core.Models.LinkGroup)")]

--- a/PokeSoulLinkBot/Persistence/RunStore.cs
+++ b/PokeSoulLinkBot/Persistence/RunStore.cs
@@ -20,24 +20,24 @@ public sealed class RunStore : IRunStore
     public RunStore(string filePath)
     {
         this.filePath = filePath;
-        jsonSerializerOptions = new JsonSerializerOptions
+        this.jsonSerializerOptions = new JsonSerializerOptions
         {
             WriteIndented = true,
         };
 
-        runs = this.LoadRuns();
+        this.runs = this.LoadRuns();
     }
 
     /// <inheritdoc />
     public SoulLinkRun? GetActiveRun(string guildId)
     {
-        return runs.LastOrDefault(run => run.GuildId == guildId && run.EndedAtUtc is null);
+        return this.runs.LastOrDefault(run => run.GuildId == guildId && run.EndedAtUtc is null);
     }
 
     /// <inheritdoc />
     public IReadOnlyList<SoulLinkRun> GetRunsForGuild(string guildId)
     {
-        return runs
+        return this.runs
             .Where(run => run.GuildId == guildId)
             .OrderByDescending(run => run.StartedAtUtc)
             .ToList();
@@ -46,32 +46,32 @@ public sealed class RunStore : IRunStore
     /// <inheritdoc />
     public void AddRun(SoulLinkRun run)
     {
-        runs.Add(run);
+        this.runs.Add(run);
         this.Save();
     }
 
     /// <inheritdoc />
     public void Save()
     {
-        string directoryPath = Path.GetDirectoryName(filePath) ?? string.Empty;
+        string directoryPath = Path.GetDirectoryName(this.filePath) ?? string.Empty;
 
         if (!string.IsNullOrWhiteSpace(directoryPath) && !Directory.Exists(directoryPath))
         {
             Directory.CreateDirectory(directoryPath);
         }
 
-        string json = JsonSerializer.Serialize(runs, jsonSerializerOptions);
-        File.WriteAllText(filePath, json);
+        string json = JsonSerializer.Serialize(this.runs, this.jsonSerializerOptions);
+        File.WriteAllText(this.filePath, json);
     }
 
     private List<SoulLinkRun> LoadRuns()
     {
-        if (!File.Exists(filePath))
+        if (!File.Exists(this.filePath))
         {
             return new List<SoulLinkRun>();
         }
 
-        string json = File.ReadAllText(filePath);
+        string json = File.ReadAllText(this.filePath);
 
         if (string.IsNullOrWhiteSpace(json))
         {


### PR DESCRIPTION
## Summary

- Disable StyleCop SA1633 centrally in `.editorconfig` because this repository does not require file headers.
- Mark BL-009 as completed in the backlog.
- Remove obsolete suppressions and clean up existing hand-written StyleCop findings touched by the build.

## Validation

- `dotnet build PokeSoulLinkBot\PokeSoulLinkBot.csproj /p:UseAppHost=false -o .codex-build`
- `dotnet test PokeSoulLinkBot.Tests\PokeSoulLinkBot.Tests.csproj /p:UseAppHost=false`

Note: the build/test still report existing project configuration/generated-code warnings `SA1516` and `SA0001`, but `SA1633` is no longer reported.