### PR TITLE
Add suggestions backlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,31 @@
 
 Diese Richtlinien gelten fuer alle Entwicklungsaufgaben in diesem Repository.
 
+## Projektkontext
+
+Dieses Repository enthaelt einen .NET-9-Discord-Bot fuer Pokemon-Soul-Link-Runs. Der Bot unterstuetzt Discord-Guilds dabei, Runs mit Spielern, Editionen, Routen, gefangenen Pokemon, Team-/Box-Zustaenden, Toden, Arena-Fortschritt und Statistiken nachzuhalten.
+
+Die Loesung besteht im Kern aus:
+
+- `PokeSoulLinkBot`: Konsolen-/Host-Anwendung mit Discord.Net-Integration, Slash Commands, Presentation/Embed-Erzeugung, Application Services, Domain-Modellen und JSON-basierter Persistenz.
+- `PokeSoulLinkBot.Tests`: xUnit-Testprojekt fuer Commands, Run-Logik, Embed-Ausgaben, Startup-Tasks und Datenservices.
+- Externen Datenquellen wie PokeAPI und PokemonDB-nahen Daten fuer Pokemon-Namen, Pokedex-Informationen, Editionen, Routen/Location Areas und Arena-Informationen.
+
+Beim Umsetzen einzelner Aufgaben soll das grosse Ganze im Blick bleiben: Der Bot soll fuer laufende Soul-Link-Runden schnell, robust, Discord-kompatibel und fuer Nutzer klar verstaendlich bleiben. Neue Funktionen sollen die Run-Daten konsistent halten, bestehende Commands nicht verlangsamen und Ausgaben so gestalten, dass sie direkt im Spielbetrieb helfen.
+
+## Arbeitsrichtlinien
+
 - Vor Beginn eines Tickets wird geprueft, ob es bereits einen passenden Branch gibt. Falls nicht, wird von `main` aus ein neuer Feature-Branch erstellt und vorher der aktuelle Stand von `origin/main` geholt.
 - Aenderungen fuer ein Ticket bleiben auf dem zugehoerigen Branch. Nach Abschluss werden die relevanten Dateien geprueft, committed und auf den Branch gepusht.
 - Git-Befehle fuer den normalen Ticket-Workflow duerfen ohne Rueckfrage ausgefuehrt werden, insbesondere `git add`, `git commit`, `git switch` und `git push` ohne Force-Optionen. Force-Pushes, auch `--force-with-lease`, duerfen nur nach ausdruecklicher Zustimmung ausgefuehrt werden.
-- Falls fuer den Task noch kein Pull Request existiert, wird nach dem Push ein Pull Request erstellt.
+- Falls fuer den Task noch kein Pull Request existiert, wird nach dem Push ein Pull Request erstellt. Wenn die Aufgabe aus Sicht von Codex abgeschlossen ist, darf der Pull Request nicht im Draft-Modus bleiben.
+- Pull Requests werden mit aussagekraeftigem Titel, nachvollziehbarer Beschreibung, passenden Labels und, soweit bekannt, sinnvollen Reviewern oder weiteren Metadaten versehen.
 - StyleCop-Anmerkungen werden immer behoben. Neuer oder geaenderter Code soll keine StyleCop-Warnungen einfuehren.
 - Code wird mit Clean-Code-Prinzipien im Blick geschrieben: klare Namen, kleine fokussierte Einheiten, geringe Kopplung und gut lesbare Kontrollfluesse.
 - SOLID-Prinzipien werden beachtet. Abhaengigkeiten, Verantwortlichkeiten und Erweiterungspunkte sollen bewusst geschnitten sein.
 - Code soll getestet sein. Neue Logik bekommt passende Tests; bestehende Tests werden angepasst, wenn sich Verhalten bewusst aendert.
+- Bei jeder Umsetzung wird aktiv geprueft, ob waehrend der Arbeit Ideen, Folgeaufgaben, Verbesserungen oder Risiken auffallen, die nicht Teil des aktuellen Tickets sind, aber spaeter sinnvoll waeren.
+- Solche nicht zum Ticket gehoerenden Ideen werden nicht nebenbei umgesetzt, sondern in `SUGGESTIONS.md` gesammelt oder aktualisiert, damit der aktuelle Scope fokussiert bleibt.
 - Vor einem Commit wird der Diff geprueft, insbesondere auf unbeabsichtigte Formatierungs-, Whitespace- oder Line-Ending-Aenderungen. Line Endings muessen dem im Repository gesetzten Standard entsprechen.
 - Manuelle Datei-Aenderungen werden direkt mit CRLF geschrieben oder unmittelbar nach dem Patch auf CRLF normalisiert. Vor dem Commit wird mit `git ls-files --eol` geprueft, dass geaenderte Textdateien nicht mit gemischten Line Endings im Worktree liegen.
 - Vor Abschluss einer Aufgabe werden relevante Formatierungs-, Analyse- und Testbefehle ausgefuehrt, soweit sie im Projekt verfuegbar und praktikabel sind.

--- a/SUGGESTIONS.md
+++ b/SUGGESTIONS.md
@@ -1,0 +1,93 @@
+# Suggestions
+
+Dieses Suggestions-Backlog sammelt Ideen, Folgeaufgaben und Verbesserungen, die waehrend der Arbeit am Projekt auffallen, aber nicht direkt Teil eines aktuellen Tickets sind.
+
+## Offen
+
+### SG-001 README mit Setup- und Betriebsanleitung ausbauen
+
+- Status: offen
+- Branch: noch keiner
+- Ziel: Die README so erweitern, dass neue Entwickler und Betreiber den Bot lokal konfigurieren, starten und testen koennen.
+- Akzeptanzkriterien:
+  - Voraussetzungen wie .NET-Version, Discord-Bot-Token und User Secrets sind beschrieben.
+  - Lokaler Start, Testausfuehrung und optionaler Publish-Build sind dokumentiert.
+  - Wichtige Konfigurationswerte aus `appsettings.json` werden erklaert, ohne Secrets zu dokumentieren.
+  - Troubleshooting-Hinweise fuer haeufige Discord- oder API-Probleme sind enthalten.
+
+### SG-002 Slash-Command-Antworten zentral absichern
+
+- Status: offen
+- Branch: noch keiner
+- Ziel: Eine zentrale Strategie fuer Discord-Interaction-Antworten definieren, damit lang laufende Commands rechtzeitig deferen und konsistent antworten.
+- Akzeptanzkriterien:
+  - Commands nutzen ein einheitliches Muster fuer `DeferAsync`, Followups und Fehlerantworten.
+  - Langsame Datenquellen koennen keinen 3-Sekunden-Interaction-Timeout mehr verursachen.
+  - Tests oder gezielte Abdeckung pruefen, dass Router und Commands Antwortpfade korrekt behandeln.
+  - Die Loesung passt zu bestehenden Embed- und Fehlerausgaben.
+
+### SG-003 Run-Daten versionieren und migrierbar machen
+
+- Status: offen
+- Branch: noch keiner
+- Ziel: Persistierte Run-Daten mit einer Version versehen, damit zukuenftige Modellveraenderungen kontrolliert migriert werden koennen.
+- Akzeptanzkriterien:
+  - Gespeicherte Run-Dateien enthalten eine Schema- oder Datenversion.
+  - Bestehende Daten ohne Version werden abwaertskompatibel geladen.
+  - Es gibt einen klaren Ort fuer Migrationen zwischen Datenversionen.
+  - Tests decken alte und aktuelle Datenformate ab.
+
+### SG-004 Datenservices mit Retry, Timeout und Cache-Policy haerten
+
+- Status: offen
+- Branch: noch keiner
+- Ziel: Externe Datenzugriffe robuster machen, damit PokeAPI- oder Netzwerkprobleme den Bot nicht unnoetig blockieren.
+- Akzeptanzkriterien:
+  - HTTP-Zugriffe haben explizite Timeouts und sinnvolle Fehlerbehandlung.
+  - Wiederholungen werden begrenzt und nur fuer geeignete Fehler eingesetzt.
+  - Cache-Verhalten ist dokumentiert und in Logs nachvollziehbar.
+  - Nutzer erhalten klare Meldungen, wenn externe Daten temporaer nicht verfuegbar sind.
+
+### SG-005 Domain-Regeln fuer Soul-Link-Konsistenz dokumentieren
+
+- Status: offen
+- Branch: noch keiner
+- Ziel: Die wichtigsten fachlichen Regeln fuer Soul-Link-Runs dokumentieren, damit neue Commands dieselben Invarianten beachten.
+- Akzeptanzkriterien:
+  - Regeln fuer Route, Link-Gruppe, Team, Box, Tod, Swap und Run-Ende sind beschrieben.
+  - Erlaubte und verbotene Zustandsuebergaenge sind nachvollziehbar dokumentiert.
+  - Die Dokumentation verweist auf relevante Services oder Tests.
+  - Offene Regelunsicherheiten sind als Fragen markiert.
+
+### SG-006 Health- oder Diagnose-Command fuer Betreiber ergaenzen
+
+- Status: offen
+- Branch: noch keiner
+- Ziel: Einen Betreiber-Command bereitstellen, der den Zustand des Bots und wichtiger Datenquellen schnell sichtbar macht.
+- Akzeptanzkriterien:
+  - Der Command zeigt Discord-Verbindung, aktiven Run, Cache-Status und externe Datenverfuegbarkeit an.
+  - Sensible Informationen wie Tokens oder Pfade mit Nutzerdaten werden nicht offengelegt.
+  - Ausgabe ist kurz genug fuer Discord und nutzt die vorhandene Ausgabe-Struktur.
+  - Fehler werden klar, aber nicht alarmistisch formuliert.
+
+### SG-007 Autocomplete-Qualitaet fuer Pokemon, Editionen und Routen verbessern
+
+- Status: offen
+- Branch: noch keiner
+- Ziel: Autocomplete-Vorschlaege priorisieren und fehlertoleranter machen, damit Commands im Spielbetrieb schneller bedienbar sind.
+- Akzeptanzkriterien:
+  - Exakte und haeufig genutzte Treffer werden vor unscharfen Treffern angezeigt.
+  - Deutsche und englische Namen funktionieren konsistent.
+  - Route- und Edition-Vorschlaege bleiben auch bei partiellen Eingaben stabil.
+  - Tests decken typische Suchbegriffe, Tippfehler und leere Eingaben ab.
+
+### SG-008 Command- und Service-Telemetrie vereinheitlichen
+
+- Status: offen
+- Branch: noch keiner
+- Ziel: Logging so strukturieren, dass Fehler und langsame Pfade im Betrieb leichter nachvollziehbar sind.
+- Akzeptanzkriterien:
+  - Slash Commands loggen Start, Dauer, Ergebnis und relevante Parameter ohne sensible Daten.
+  - Externe Datenzugriffe und Cache-Entscheidungen sind mit konsistenten Event-Namen sichtbar.
+  - Fehlerlogs enthalten genug Kontext fuer Debugging, ohne Discord-Nachrichten zu ueberfrachten.
+  - Tests oder Review-Checklisten stellen sicher, dass neue Commands das Muster verwenden.


### PR DESCRIPTION
## Zweck

Fuegt ein zweites Backlog fuer Suggestions hinzu und erweitert AGENTS.md um Projektkontext sowie den Prozess, Nebenideen nicht im aktuellen Ticket-Scope umzusetzen, sondern gesammelt festzuhalten.

## Aenderungen

- Neue `SUGGESTIONS.md` im Backlog-Format mit ersten Ideen und Akzeptanzkriterien.
- AGENTS.md um Projektbeschreibung fuer den Discord-Soul-Link-Bot erweitert.
- AGENTS.md um Richtlinie ergaenzt, waehrend jeder Aufgabe nicht-scope-relevante Ideen fuer `SUGGESTIONS.md` zu sammeln.

## Verifikation

- `git diff --check`
- `git ls-files --eol AGENTS.md SUGGESTIONS.md`
- Kein Testlauf, da reine Dokumentationsaenderung ohne Codepfad.