### PR TITLE
BL-003 DeathCommand um Reason und Spieler erweitern

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -28,8 +28,8 @@ Dieses Backlog sammelt fachliche und technische Aufgaben fuer die naechsten Iter
 
 ### BL-003 DeathCommand um Reason und verursachenden Spieler erweitern
 
-- Status: offen
-- Branch: noch keiner
+- Status: umgesetzt
+- Branch: codex/bl-003-death-reason-player
 - Ziel: Der DeathCommand bekommt eine Reason und optional einen Spieler, der Schuld war.
 - Akzeptanzkriterien:
   - `reason` ist als Command-Parameter verfuegbar.

--- a/PokeSoulLinkBot.Tests/CommandDefinitionTests.cs
+++ b/PokeSoulLinkBot.Tests/CommandDefinitionTests.cs
@@ -16,7 +16,7 @@ public sealed class CommandDefinitionTests
         {
             { new ArenaCommand(new StubArenaInfoService(), new EmbedFactory(), CreateImageFactory(), new StubGameDataCatalogService(), new StubRunService()), "arena", new[] { "number", "edition" } },
             { new CatchCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory(), new StubPokemonLookupService(), new StubGameDataCatalogService()), "catch", new[] { "route", "player", "pokemon" } },
-            { new DeathCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory()), "death", new[] { "route" } },
+            { new DeathCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory()), "death", new[] { "route", "reason", "player" } },
             { new PokedexCommand(new StubPokedexService(), new PokedexPresenter()), "pokedex", new[] { "name" } },
             { new RouteDeathCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory(), new StubGameDataCatalogService()), "route-death", new[] { "route", "reason", "player" } },
             { new RunEndCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory()), "run-end", new[] { "reason" } },
@@ -90,7 +90,12 @@ public sealed class CommandDefinitionTests
             throw new NotSupportedException();
         }
 
-        public LinkGroup RegisterDeath(string guildId, string pokemon)
+        public LinkGroup RegisterDeath(
+            string guildId,
+            string route,
+            string reason,
+            ulong? playerId,
+            string? playerName)
         {
             throw new NotSupportedException();
         }

--- a/PokeSoulLinkBot.Tests/EmbedFactoryStatusTests.cs
+++ b/PokeSoulLinkBot.Tests/EmbedFactoryStatusTests.cs
@@ -51,6 +51,22 @@ public sealed class EmbedFactoryStatusTests
     }
 
     [Fact]
+    public void CreateDeathRegisteredEmbed_ShouldIncludeReasonAndCausingPlayer()
+    {
+        var linkGroup = CreateLinkGroup("101", false, "Bisasam");
+        var entry = Assert.Single(linkGroup.Entries);
+        entry.DeathReason = "Critical hit.";
+        entry.DeathCausedByPlayerName = "bene";
+        var embedFactory = new EmbedFactory();
+
+        var embed = embedFactory.CreateDeathRegisteredEmbed(linkGroup, "attachment://death.png");
+
+        Assert.Contains(embed.Fields, field => field.Name == "Reason" && field.Value == "Critical hit.");
+        Assert.Contains(embed.Fields, field => field.Name == "Player" && field.Value == "bene");
+        Assert.Contains(embed.Fields, field => field.Name == "Affected Pokemon" && field.Value.Contains("Bisasam", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void CreateStatusMessage_ShouldKeepTableCodeBlocksDiscordCompatible()
     {
         var run = CreateRun();

--- a/PokeSoulLinkBot.Tests/RunServiceCatchTests.cs
+++ b/PokeSoulLinkBot.Tests/RunServiceCatchTests.cs
@@ -83,14 +83,29 @@ public sealed class RunServiceCatchTests
         var linkGroup = service.RegisterCatch(GuildId, "101", 1, "marpie1", "Bisasam", Array.Empty<string>());
         service.RegisterCatch(GuildId, "101", 2, "bene", "Pichu", Array.Empty<string>());
 
-        var deadGroup = service.RegisterDeath(GuildId, "101");
+        var deadGroup = service.RegisterDeath(GuildId, "101", "Critical hit.", 2, "bene");
 
         Assert.Same(linkGroup, deadGroup);
         Assert.All(deadGroup.Entries, entry =>
         {
             Assert.False(entry.IsAlive);
             Assert.NotNull(entry.DiedAtUtc);
+            Assert.Equal("Critical hit.", entry.DeathReason);
+            Assert.Equal(2UL, entry.DeathCausedByPlayerUserId);
+            Assert.Equal("bene", entry.DeathCausedByPlayerName);
         });
+    }
+
+    [Fact]
+    public void RegisterDeath_ShouldRejectPlayerOutsideRun()
+    {
+        var service = CreateServiceWithStartedRun();
+        service.RegisterCatch(GuildId, "101", 1, "marpie1", "Bisasam", Array.Empty<string>());
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            service.RegisterDeath(GuildId, "101", "Critical hit.", 99, "outsider"));
+
+        Assert.Equal("The specified player is not part of the active run.", exception.Message);
     }
 
     [Fact]
@@ -296,7 +311,7 @@ public sealed class RunServiceCatchTests
     {
         var service = CreateServiceWithStartedRun();
         service.RegisterCatch(GuildId, "101", 1, "marpie1", "Bisasam", Array.Empty<string>());
-        service.RegisterDeath(GuildId, "101");
+        service.RegisterDeath(GuildId, "101", "Critical hit.", null, null);
 
         var exception = Assert.Throws<InvalidOperationException>(() => service.UseRoute(GuildId, "101", 1));
 

--- a/PokeSoulLinkBot/Application/Interfaces/IRunService.cs
+++ b/PokeSoulLinkBot/Application/Interfaces/IRunService.cs
@@ -81,9 +81,17 @@ public interface IRunService
     /// Registers the death of a Pokémon and marks the whole linked group as dead.
     /// </summary>
     /// <param name="guildId">The Discord guild identifier.</param>
-    /// <param name="pokemon">The Pokémon name.</param>
+    /// <param name="route">The route or area name.</param>
+    /// <param name="reason">The reason why the linked Pokémon died.</param>
+    /// <param name="playerId">The optional Discord user identifier of the player responsible for the death.</param>
+    /// <param name="playerName">The optional display name of the player responsible for the death.</param>
     /// <returns>The affected link group.</returns>
-    LinkGroup RegisterDeath(string guildId, string pokemon);
+    LinkGroup RegisterDeath(
+        string guildId,
+        string route,
+        string reason,
+        ulong? playerId,
+        string? playerName);
 
     /// <summary>
     /// Gets the currently active run for the specified guild.

--- a/PokeSoulLinkBot/Application/Services/RunService.cs
+++ b/PokeSoulLinkBot/Application/Services/RunService.cs
@@ -228,12 +228,23 @@ public sealed class RunService : IRunService
     }
 
     /// <inheritdoc />
-    public LinkGroup RegisterDeath(string guildId, string route)
+    public LinkGroup RegisterDeath(
+        string guildId,
+        string route,
+        string reason,
+        ulong? playerId,
+        string? playerName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(guildId);
         ArgumentException.ThrowIfNullOrWhiteSpace(route);
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
 
         SoulLinkRun activeRun = this.GetActiveRun(guildId);
+
+        if (playerId.HasValue && activeRun.Players.All(player => player.UserId != playerId.Value))
+        {
+            throw new InvalidOperationException("The specified player is not part of the active run.");
+        }
 
         LinkGroup? linkGroup = activeRun.LinkGroups.FirstOrDefault(group =>
             group.Route.Equals(route, StringComparison.OrdinalIgnoreCase));
@@ -247,6 +258,11 @@ public sealed class RunService : IRunService
         {
             entry.IsAlive = false;
             entry.DiedAtUtc = DateTime.UtcNow;
+            entry.DeathReason = reason.Trim();
+            entry.DeathCausedByPlayerUserId = playerId;
+            entry.DeathCausedByPlayerName = string.IsNullOrWhiteSpace(playerName)
+                ? null
+                : playerName.Trim();
         }
 
         this.runStore.Save();

--- a/PokeSoulLinkBot/Bot/Commands/DeathCommand.cs
+++ b/PokeSoulLinkBot/Bot/Commands/DeathCommand.cs
@@ -46,6 +46,8 @@ public class DeathCommand : ISlashCommand
             .WithName(this.CommandName)
             .WithDescription("Register the death of a linked Pokémon group.")
             .AddOption("route", ApplicationCommandOptionType.String, "The route that is now dead.", isRequired: true, isAutocomplete: true)
+            .AddOption("reason", ApplicationCommandOptionType.String, "Why the linked Pokémon died.", isRequired: true)
+            .AddOption("player", ApplicationCommandOptionType.User, "The player who caused the death.", isRequired: false)
             .Build();
     }
 
@@ -57,8 +59,15 @@ public class DeathCommand : ISlashCommand
         var guildId = CommandOptionHelper.GetGuildId(command);
 
         var route = CommandOptionHelper.GetRequiredStringOption(command, "route");
+        var reason = CommandOptionHelper.GetRequiredStringOption(command, "reason");
+        var player = CommandOptionHelper.GetOptionalUserOption(command, "player");
 
-        var linkGroup = this.runService.RegisterDeath(guildId, route);
+        var linkGroup = this.runService.RegisterDeath(
+            guildId,
+            route,
+            reason,
+            player?.Id,
+            player?.Username);
         var image = this.embedImageFactory.CreateDeathImage();
         var embed = this.embedFactory.CreateDeathRegisteredEmbed(linkGroup, image.AttachmentUrl);
 

--- a/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
+++ b/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
@@ -148,16 +148,29 @@ public sealed class EmbedFactory
         var entries = string.Join(
             Environment.NewLine,
             linkGroup.Entries.Select(entry => $"{entry.PlayerName}: {entry.PokemonName}"));
+        var deathReason = linkGroup.Entries
+            .Select(entry => entry.DeathReason)
+            .FirstOrDefault(reason => !string.IsNullOrWhiteSpace(reason));
+        var causedByPlayer = linkGroup.Entries
+            .Select(entry => entry.DeathCausedByPlayerName)
+            .FirstOrDefault(playerName => !string.IsNullOrWhiteSpace(playerName));
 
-        return new EmbedBuilder()
+        var builder = new EmbedBuilder()
             .WithTitle("Death Registered")
             .WithColor(new Color(128, 0, 128))
             .WithDescription($"The linked group on **{linkGroup.Route}** has been marked as dead.")
             .AddField("Route", linkGroup.Route, true)
             .AddField("Status", "Dead", true)
+            .AddField("Reason", deathReason ?? "No reason given.")
             .AddField("Affected Pokemon", entries)
-            .WithThumbnailUrl(thumbnailUrl)
-            .Build();
+            .WithThumbnailUrl(thumbnailUrl);
+
+        if (!string.IsNullOrWhiteSpace(causedByPlayer))
+        {
+            builder.AddField("Player", causedByPlayer, true);
+        }
+
+        return builder.Build();
     }
 
     /// <summary>

--- a/PokeSoulLinkBot/Core/Models/LinkedPokemon.cs
+++ b/PokeSoulLinkBot/Core/Models/LinkedPokemon.cs
@@ -39,4 +39,19 @@ public sealed class LinkedPokemon
     /// Gets or sets the UTC date and time when the Pokémon died.
     /// </summary>
     public DateTime? DiedAtUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the reason why the Pokémon died.
+    /// </summary>
+    public string? DeathReason { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Discord user identifier of the player responsible for the death.
+    /// </summary>
+    public ulong? DeathCausedByPlayerUserId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Discord user name of the player responsible for the death.
+    /// </summary>
+    public string? DeathCausedByPlayerName { get; set; }
 }


### PR DESCRIPTION
## Zweck
- BL-003 umsetzen: `/death` erfasst jetzt einen verpflichtenden Grund und optional den verursachenden Spieler.

## Aenderungen
- DeathCommand-Definition um `reason` und optionalen `player` erweitert.
- Todesgrund und verursachender Spieler werden auf den betroffenen Pokemon persistiert.
- Death-Embed zeigt Route, Status, Grund, betroffene Pokemon und optional den Spieler.
- Backlog-Status fuer BL-003 aktualisiert.

## Verifikation
- `dotnet build PokeSoulLinkBot\PokeSoulLinkBot.csproj /p:UseAppHost=false /p:UseSharedCompilation=false /p:TreatWarningsAsErrors=true /warnaserror:SA1516 -v:minimal`
- `dotnet test PokeSoulLinkBot.Tests\PokeSoulLinkBot.Tests.csproj /p:UseAppHost=false /p:UseSharedCompilation=false`