### PR TITLE
Add catch eligibility command

### DIFF
--- a/PokeSoulLinkBot.Tests/CatchEligibilityServiceTests.cs
+++ b/PokeSoulLinkBot.Tests/CatchEligibilityServiceTests.cs
@@ -1,0 +1,230 @@
+using PokeSoulLinkBot.Application.Interfaces;
+using PokeSoulLinkBot.Application.Services;
+using PokeSoulLinkBot.Core.Models;
+using Xunit;
+
+namespace PokeSoulLinkBot.Tests;
+
+public sealed class CatchEligibilityServiceTests
+{
+    private const string GuildId = "guild-1";
+
+    [Fact]
+    public async Task CheckCatchAsync_ShouldBlockGermanNameWhenEvolutionLineWasAlreadyCaught()
+    {
+        var linkGroup = CreateLinkGroup("route 1", 1, "Ash", "Bulbasaur", isAlive: true);
+        var service = CreateService(CreateRun(linkGroup));
+
+        var result = await service.CheckCatchAsync(GuildId, "Bisasam");
+
+        Assert.False(result.IsAllowed);
+        Assert.NotNull(result.Match);
+        Assert.Equal("route 1", result.Match.Route);
+        Assert.Equal("Ash", result.Match.PlayerName);
+        Assert.Equal("Bulbasaur", result.Match.PokemonName);
+        Assert.Equal("Team", result.Match.Status);
+    }
+
+    [Fact]
+    public async Task CheckCatchAsync_ShouldBlockEnglishEvolutionWhenBaseFormWasAlreadyCaught()
+    {
+        var linkGroup = CreateLinkGroup("route 1", 1, "Ash", "Bulbasaur", isAlive: true);
+        var service = CreateService(CreateRun(linkGroup));
+
+        var result = await service.CheckCatchAsync(GuildId, "Venusaur");
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal("Bulbasaur", result.Match?.PokemonName);
+    }
+
+    [Fact]
+    public async Task CheckCatchAsync_ShouldConsiderDeadPokemonAsBlocked()
+    {
+        var linkGroup = CreateLinkGroup("route 2", 2, "Misty", "Charmander", isAlive: false);
+        var service = CreateService(CreateRun(linkGroup));
+
+        var result = await service.CheckCatchAsync(GuildId, "Charmeleon");
+
+        Assert.False(result.IsAllowed);
+        Assert.NotNull(result.Match);
+        Assert.Equal("Charmander", result.Match.PokemonName);
+        Assert.Equal("Dead", result.Match.Status);
+    }
+
+    [Fact]
+    public async Task CheckCatchAsync_ShouldAllowPokemonWithoutEvolutionLineMatch()
+    {
+        var linkGroup = CreateLinkGroup("route 1", 1, "Ash", "Bulbasaur", isAlive: true);
+        var service = CreateService(CreateRun(linkGroup));
+
+        var result = await service.CheckCatchAsync(GuildId, "Squirtle");
+
+        Assert.True(result.IsAllowed);
+        Assert.Null(result.Match);
+    }
+
+    [Fact]
+    public async Task CheckCatchAsync_ShouldReportUnclearPokemonName()
+    {
+        var service = CreateService(CreateRun());
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CheckCatchAsync(GuildId, "Missingno"));
+
+        Assert.Contains("not found or is ambiguous", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CatchEligibilityService CreateService(SoulLinkRun run)
+    {
+        return new CatchEligibilityService(new StubRunService(run), new StubPokedexService());
+    }
+
+    private static SoulLinkRun CreateRun(params LinkGroup[] linkGroups)
+    {
+        var run = new SoulLinkRun
+        {
+            GuildId = GuildId,
+            Name = "Test Run",
+            Game = "red",
+            Players = new List<RunPlayer>
+            {
+                new RunPlayer { UserId = 1, UserName = "Ash" },
+                new RunPlayer { UserId = 2, UserName = "Misty" },
+            },
+            LinkGroups = linkGroups.ToList(),
+        };
+
+        if (linkGroups.FirstOrDefault(group => group.IsAlive) is { } aliveGroup)
+        {
+            run.ActiveLinks[0] = aliveGroup;
+        }
+
+        return run;
+    }
+
+    private static LinkGroup CreateLinkGroup(
+        string route,
+        ulong playerId,
+        string playerName,
+        string pokemonName,
+        bool isAlive)
+    {
+        return new LinkGroup
+        {
+            Id = Guid.NewGuid(),
+            Route = route,
+            Entries = new List<LinkedPokemon>
+            {
+                new LinkedPokemon
+                {
+                    PlayerUserId = playerId,
+                    PlayerName = playerName,
+                    PokemonName = pokemonName,
+                    IsAlive = isAlive,
+                },
+            },
+        };
+    }
+
+    private sealed class StubRunService : IRunService
+    {
+        private readonly SoulLinkRun run;
+
+        public StubRunService(SoulLinkRun run)
+        {
+            this.run = run;
+        }
+
+        public SoulLinkRun StartRun(string guildId, string name, string game, IReadOnlyList<RunPlayer> players)
+        {
+            throw new NotSupportedException();
+        }
+
+        public SoulLinkRun EndRun(string guildId, string? reason)
+        {
+            throw new NotSupportedException();
+        }
+
+        public LinkGroup RegisterCatch(
+            string guildId,
+            string route,
+            ulong playerId,
+            string playerName,
+            string pokemon,
+            IReadOnlyList<string> pokemonTypes)
+        {
+            throw new NotSupportedException();
+        }
+
+        public LinkGroup MarkRouteLost(
+            string guildId,
+            string route,
+            string? reason,
+            ulong? playerId,
+            string? playerName)
+        {
+            throw new NotSupportedException();
+        }
+
+        public SoulLinkRun UseRoute(string guildId, string route, int position)
+        {
+            throw new NotSupportedException();
+        }
+
+        public SoulLinkRun SwapRoute(string guildId, string teamRoute, string boxRoute)
+        {
+            throw new NotSupportedException();
+        }
+
+        public LinkGroup RegisterDeath(
+            string guildId,
+            string route,
+            string reason,
+            ulong? playerId,
+            string? playerName)
+        {
+            throw new NotSupportedException();
+        }
+
+        public SoulLinkRun GetActiveRun(string guildId)
+        {
+            return this.run;
+        }
+
+        public IReadOnlyList<SoulLinkRun> GetRuns(string guildId)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed class StubPokedexService : IPokedexService
+    {
+        private static readonly IReadOnlyDictionary<string, string[]> Families =
+            new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Bulbasaur"] = new[] { "Bulbasaur", "Ivysaur", "Venusaur" },
+                ["Bisasam"] = new[] { "Bulbasaur", "Ivysaur", "Venusaur" },
+                ["Ivysaur"] = new[] { "Bulbasaur", "Ivysaur", "Venusaur" },
+                ["Venusaur"] = new[] { "Bulbasaur", "Ivysaur", "Venusaur" },
+                ["Charmander"] = new[] { "Charmander", "Charmeleon", "Charizard" },
+                ["Charmeleon"] = new[] { "Charmander", "Charmeleon", "Charizard" },
+                ["Squirtle"] = new[] { "Squirtle", "Wartortle", "Blastoise" },
+            };
+
+        public Task<PokedexEntry> GetPokedexEntryAsync(string pokemonName)
+        {
+            if (!Families.TryGetValue(pokemonName, out var family))
+            {
+                throw new InvalidOperationException("Pokémon was not found.");
+            }
+
+            var entry = new PokedexEntry
+            {
+                PokemonName = pokemonName,
+                Rows = family.Select(name => new PokedexTableRow { PokemonName = name }).ToList(),
+            };
+
+            return Task.FromResult(entry);
+        }
+    }
+}

--- a/PokeSoulLinkBot.Tests/CatchEligibilityServiceTests.cs
+++ b/PokeSoulLinkBot.Tests/CatchEligibilityServiceTests.cs
@@ -64,6 +64,31 @@ public sealed class CatchEligibilityServiceTests
     }
 
     [Fact]
+    public async Task CheckCatchAsync_ShouldIgnoreUnresolvedStoredCatchWhenItDoesNotMatchRequestedPokemon()
+    {
+        var linkGroup = CreateLinkGroup("route 3", 2, "Misty", "Quieckel", isAlive: true);
+        var service = CreateService(CreateRun(linkGroup));
+
+        var result = await service.CheckCatchAsync(GuildId, "Raichu");
+
+        Assert.True(result.IsAllowed);
+        Assert.Null(result.Match);
+    }
+
+    [Fact]
+    public async Task CheckCatchAsync_ShouldBlockUnresolvedStoredCatchOnKnownFamilyMemberMatch()
+    {
+        var linkGroup = CreateLinkGroup("route 3", 2, "Misty", "Pikachu", isAlive: true);
+        var service = CreateService(CreateRun(linkGroup));
+
+        var result = await service.CheckCatchAsync(GuildId, "Raichu");
+
+        Assert.False(result.IsAllowed);
+        Assert.NotNull(result.Match);
+        Assert.Equal("Pikachu", result.Match.PokemonName);
+    }
+
+    [Fact]
     public async Task CheckCatchAsync_ShouldReportUnclearPokemonName()
     {
         var service = CreateService(CreateRun());
@@ -208,6 +233,7 @@ public sealed class CatchEligibilityServiceTests
                 ["Venusaur"] = new[] { "Bulbasaur", "Ivysaur", "Venusaur" },
                 ["Charmander"] = new[] { "Charmander", "Charmeleon", "Charizard" },
                 ["Charmeleon"] = new[] { "Charmander", "Charmeleon", "Charizard" },
+                ["Raichu"] = new[] { "Pichu", "Pikachu", "Raichu" },
                 ["Squirtle"] = new[] { "Squirtle", "Wartortle", "Blastoise" },
             };
 

--- a/PokeSoulLinkBot.Tests/CommandDefinitionTests.cs
+++ b/PokeSoulLinkBot.Tests/CommandDefinitionTests.cs
@@ -16,6 +16,7 @@ public sealed class CommandDefinitionTests
         {
             { new ArenaCommand(new StubArenaInfoService(), new EmbedFactory(), CreateImageFactory(), new StubGameDataCatalogService(), new StubRunService()), "arena", new[] { "number", "edition" } },
             { new CatchCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory(), new StubPokemonLookupService(), new StubGameDataCatalogService()), "catch", new[] { "route", "player", "pokemon" } },
+            { new CatchCheckCommand(new StubCatchEligibilityService(), new EmbedFactory()), "catch-check", new[] { "pokemon" } },
             { new DeathCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory()), "death", new[] { "route", "reason", "player" } },
             { new PokedexCommand(new StubPokedexService(), new PokedexPresenter()), "pokedex", new[] { "name" } },
             { new RouteDeathCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory(), new StubGameDataCatalogService()), "route-death", new[] { "route", "reason", "player" } },
@@ -134,6 +135,14 @@ public sealed class CommandDefinitionTests
     private sealed class StubPokemonLookupService : IPokemonLookupService
     {
         public Task<PokemonInfo?> GetPokemonInfoAsync(string pokemonName)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed class StubCatchEligibilityService : ICatchEligibilityService
+    {
+        public Task<CatchCheckResult> CheckCatchAsync(string guildId, string pokemonName)
         {
             throw new NotSupportedException();
         }

--- a/PokeSoulLinkBot.Tests/EmbedFactoryStatusTests.cs
+++ b/PokeSoulLinkBot.Tests/EmbedFactoryStatusTests.cs
@@ -64,6 +64,49 @@ public sealed class EmbedFactoryStatusTests
     }
 
     [Fact]
+    public void CreateCatchCheckEmbed_ShouldUseShortGermanAllowedOutput()
+    {
+        var result = new CatchCheckResult
+        {
+            RequestedPokemonName = "Raichu",
+            IsAllowed = true,
+        };
+        var embedFactory = new EmbedFactory();
+
+        var embed = embedFactory.CreateCatchCheckEmbed(result);
+
+        Assert.Equal("Fang-Check", embed.Title);
+        Assert.Equal("✅ **Raichu** darf gefangen werden.", embed.Description);
+        Assert.Empty(embed.Fields);
+    }
+
+    [Fact]
+    public void CreateCatchCheckEmbed_ShouldUseShortGermanBlockedOutput()
+    {
+        var result = new CatchCheckResult
+        {
+            RequestedPokemonName = "Raichu",
+            IsAllowed = false,
+            Match = new CatchCheckMatch
+            {
+                PokemonName = "Pikachu",
+                Route = "route 3",
+                PlayerName = "Misty",
+                Status = "Dead",
+            },
+        };
+        var embedFactory = new EmbedFactory();
+
+        var embed = embedFactory.CreateCatchCheckEmbed(result);
+
+        Assert.Equal("Fang-Check", embed.Title);
+        Assert.Equal("⛔ **Raichu** ist gesperrt.", embed.Description);
+        var field = Assert.Single(embed.Fields);
+        Assert.Equal("Fund", field.Name);
+        Assert.Equal("Pikachu · route 3 · Misty · Tot", field.Value);
+    }
+
+    [Fact]
     public void CreateStatusMessages_ShouldKeepAllTableRowsWithoutContinuationSections()
     {
         var run = CreateRun();

--- a/PokeSoulLinkBot/Application/Interfaces/ICatchEligibilityService.cs
+++ b/PokeSoulLinkBot/Application/Interfaces/ICatchEligibilityService.cs
@@ -1,0 +1,17 @@
+using PokeSoulLinkBot.Core.Models;
+
+namespace PokeSoulLinkBot.Application.Interfaces;
+
+/// <summary>
+/// Checks whether a Pokémon may still be caught in an active run.
+/// </summary>
+public interface ICatchEligibilityService
+{
+    /// <summary>
+    /// Checks if a Pokémon or any member of its evolution line already appears in the active run.
+    /// </summary>
+    /// <param name="guildId">The Discord guild identifier.</param>
+    /// <param name="pokemonName">The Pokémon name to check.</param>
+    /// <returns>The catch check result.</returns>
+    Task<CatchCheckResult> CheckCatchAsync(string guildId, string pokemonName);
+}

--- a/PokeSoulLinkBot/Application/Services/CatchEligibilityService.cs
+++ b/PokeSoulLinkBot/Application/Services/CatchEligibilityService.cs
@@ -38,7 +38,7 @@ public sealed class CatchEligibilityService : ICatchEligibilityService
         {
             foreach (var entry in linkGroup.Entries)
             {
-                var caughtFamily = await this.GetEvolutionFamilyAsync(entry.PokemonName, familyCache);
+                var caughtFamily = await this.GetStoredCatchFamilyAsync(entry.PokemonName, familyCache);
                 if (!requestedFamily.Overlaps(caughtFamily))
                 {
                     continue;
@@ -91,6 +91,26 @@ public sealed class CatchEligibilityService : ICatchEligibilityService
             .Replace(" ", string.Empty, StringComparison.Ordinal)
             .Replace("-", string.Empty, StringComparison.Ordinal)
             .Replace("_", string.Empty, StringComparison.Ordinal);
+    }
+
+    private async Task<HashSet<string>> GetStoredCatchFamilyAsync(
+        string pokemonName,
+        Dictionary<string, HashSet<string>> familyCache)
+    {
+        try
+        {
+            return await this.GetEvolutionFamilyAsync(pokemonName, familyCache);
+        }
+        catch (InvalidOperationException)
+        {
+            var family = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                NormalizePokemonName(pokemonName),
+            };
+
+            familyCache[pokemonName] = family;
+            return family;
+        }
     }
 
     private async Task<HashSet<string>> GetEvolutionFamilyAsync(

--- a/PokeSoulLinkBot/Application/Services/CatchEligibilityService.cs
+++ b/PokeSoulLinkBot/Application/Services/CatchEligibilityService.cs
@@ -1,0 +1,124 @@
+using PokeSoulLinkBot.Application.Interfaces;
+using PokeSoulLinkBot.Core.Models;
+
+namespace PokeSoulLinkBot.Application.Services;
+
+/// <summary>
+/// Provides catch eligibility checks for active Soul Link runs.
+/// </summary>
+public sealed class CatchEligibilityService : ICatchEligibilityService
+{
+    private readonly IRunService runService;
+    private readonly IPokedexService pokedexService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CatchEligibilityService"/> class.
+    /// </summary>
+    /// <param name="runService">The run service.</param>
+    /// <param name="pokedexService">The Pokédex service.</param>
+    public CatchEligibilityService(
+        IRunService runService,
+        IPokedexService pokedexService)
+    {
+        this.runService = runService ?? throw new ArgumentNullException(nameof(runService));
+        this.pokedexService = pokedexService ?? throw new ArgumentNullException(nameof(pokedexService));
+    }
+
+    /// <inheritdoc />
+    public async Task<CatchCheckResult> CheckCatchAsync(string guildId, string pokemonName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(guildId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(pokemonName);
+
+        var activeRun = this.runService.GetActiveRun(guildId);
+        var familyCache = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        var requestedFamily = await this.GetEvolutionFamilyAsync(pokemonName, familyCache);
+
+        foreach (var linkGroup in activeRun.LinkGroups)
+        {
+            foreach (var entry in linkGroup.Entries)
+            {
+                var caughtFamily = await this.GetEvolutionFamilyAsync(entry.PokemonName, familyCache);
+                if (!requestedFamily.Overlaps(caughtFamily))
+                {
+                    continue;
+                }
+
+                return new CatchCheckResult
+                {
+                    RequestedPokemonName = pokemonName,
+                    IsAllowed = false,
+                    Match = new CatchCheckMatch
+                    {
+                        Route = linkGroup.Route,
+                        PlayerName = entry.PlayerName,
+                        PokemonName = entry.PokemonName,
+                        Status = GetStatus(activeRun, linkGroup, entry),
+                    },
+                };
+            }
+        }
+
+        return new CatchCheckResult
+        {
+            RequestedPokemonName = pokemonName,
+            IsAllowed = true,
+        };
+    }
+
+    private static string GetStatus(SoulLinkRun run, LinkGroup linkGroup, LinkedPokemon pokemon)
+    {
+        if (!pokemon.IsAlive)
+        {
+            return "Dead";
+        }
+
+        var isInTeam = run.ActiveLinks.Any(activeLink =>
+            activeLink is not null &&
+            (ReferenceEquals(activeLink, linkGroup) ||
+                activeLink.Id == linkGroup.Id ||
+                string.Equals(activeLink.Route, linkGroup.Route, StringComparison.OrdinalIgnoreCase)));
+
+        return isInTeam ? "Team" : "Box";
+    }
+
+    private static string NormalizePokemonName(string pokemonName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pokemonName);
+
+        return pokemonName.Trim()
+            .ToLowerInvariant()
+            .Replace(" ", string.Empty, StringComparison.Ordinal)
+            .Replace("-", string.Empty, StringComparison.Ordinal)
+            .Replace("_", string.Empty, StringComparison.Ordinal);
+    }
+
+    private async Task<HashSet<string>> GetEvolutionFamilyAsync(
+        string pokemonName,
+        Dictionary<string, HashSet<string>> familyCache)
+    {
+        if (familyCache.TryGetValue(pokemonName, out var cachedFamily))
+        {
+            return cachedFamily;
+        }
+
+        try
+        {
+            var pokedexEntry = await this.pokedexService.GetPokedexEntryAsync(pokemonName);
+            var family = pokedexEntry.Rows
+                .Select(row => NormalizePokemonName(row.PokemonName))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            family.Add(NormalizePokemonName(pokedexEntry.PokemonName));
+            familyCache[pokemonName] = family;
+
+            return family;
+        }
+        catch (InvalidOperationException exception)
+        {
+            throw new InvalidOperationException(
+                $"Pokémon '{pokemonName}' was not found or is ambiguous. Check the German or English name.",
+                exception);
+        }
+    }
+}

--- a/PokeSoulLinkBot/Bot/Commands/CatchCheckCommand.cs
+++ b/PokeSoulLinkBot/Bot/Commands/CatchCheckCommand.cs
@@ -1,0 +1,55 @@
+using Discord;
+using Discord.WebSocket;
+using PokeSoulLinkBot.Application.Interfaces;
+using PokeSoulLinkBot.Bot.Factories;
+using PokeSoulLinkBot.Bot.Helpers;
+
+namespace PokeSoulLinkBot.Bot.Commands;
+
+/// <summary>
+/// Handles the "catch-check" slash command.
+/// </summary>
+public sealed class CatchCheckCommand : ISlashCommand
+{
+    private readonly ICatchEligibilityService catchEligibilityService;
+    private readonly EmbedFactory embedFactory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CatchCheckCommand"/> class.
+    /// </summary>
+    /// <param name="catchEligibilityService">The catch eligibility service.</param>
+    /// <param name="embedFactory">The embed factory.</param>
+    public CatchCheckCommand(
+        ICatchEligibilityService catchEligibilityService,
+        EmbedFactory embedFactory)
+    {
+        this.catchEligibilityService = catchEligibilityService ?? throw new ArgumentNullException(nameof(catchEligibilityService));
+        this.embedFactory = embedFactory ?? throw new ArgumentNullException(nameof(embedFactory));
+    }
+
+    /// <inheritdoc />
+    public string CommandName => "catch-check";
+
+    /// <inheritdoc />
+    public ApplicationCommandProperties BuildDefinition()
+    {
+        return new SlashCommandBuilder()
+            .WithName(this.CommandName)
+            .WithDescription("Checks whether a Pokémon may still be caught in the active run.")
+            .AddOption("pokemon", ApplicationCommandOptionType.String, "The Pokémon name.", isRequired: true)
+            .Build();
+    }
+
+    /// <inheritdoc />
+    public async Task HandleAsync(SocketSlashCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var guildId = CommandOptionHelper.GetGuildId(command);
+        var pokemonName = CommandOptionHelper.GetRequiredStringOption(command, "pokemon");
+        var result = await this.catchEligibilityService.CheckCatchAsync(guildId, pokemonName);
+        var embed = this.embedFactory.CreateCatchCheckEmbed(result);
+
+        await SlashCommandResponse.SendAsync(command, embed: embed);
+    }
+}

--- a/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
+++ b/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
@@ -125,6 +125,43 @@ public sealed class EmbedFactory
     }
 
     /// <summary>
+    /// Creates an embed for a catch eligibility check.
+    /// </summary>
+    /// <param name="result">The catch check result.</param>
+    /// <returns>The created embed.</returns>
+    public Embed CreateCatchCheckEmbed(CatchCheckResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentException.ThrowIfNullOrWhiteSpace(result.RequestedPokemonName);
+
+        if (result.IsAllowed)
+        {
+            return new EmbedBuilder()
+                .WithTitle("Catch Check")
+                .WithColor(Color.Green)
+                .WithDescription($"**{result.RequestedPokemonName}** may still be caught in this run.")
+                .AddField("Pokemon", result.RequestedPokemonName, true)
+                .AddField("Result", "Allowed", true)
+                .Build();
+        }
+
+        var match = result.Match
+            ?? throw new InvalidOperationException("Blocked catch checks must include the matching catch.");
+
+        return new EmbedBuilder()
+            .WithTitle("Catch Check")
+            .WithColor(Color.Red)
+            .WithDescription($"**{result.RequestedPokemonName}** may not be caught because this evolution line already appears in the run.")
+            .AddField("Pokemon", result.RequestedPokemonName, true)
+            .AddField("Result", "Blocked", true)
+            .AddField("Matched Pokemon", match.PokemonName, true)
+            .AddField("Route", match.Route, true)
+            .AddField("Player", match.PlayerName, true)
+            .AddField("Status", match.Status, true)
+            .Build();
+    }
+
+    /// <summary>
     /// Creates an embed for a linked group death.
     /// </summary>
     /// <param name="linkGroup">The affected link group.</param>

--- a/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
+++ b/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
@@ -137,11 +137,9 @@ public sealed class EmbedFactory
         if (result.IsAllowed)
         {
             return new EmbedBuilder()
-                .WithTitle("Catch Check")
+                .WithTitle("Fang-Check")
                 .WithColor(Color.Green)
-                .WithDescription($"**{result.RequestedPokemonName}** may still be caught in this run.")
-                .AddField("Pokemon", result.RequestedPokemonName, true)
-                .AddField("Result", "Allowed", true)
+                .WithDescription($"✅ **{result.RequestedPokemonName}** darf gefangen werden.")
                 .Build();
         }
 
@@ -149,15 +147,10 @@ public sealed class EmbedFactory
             ?? throw new InvalidOperationException("Blocked catch checks must include the matching catch.");
 
         return new EmbedBuilder()
-            .WithTitle("Catch Check")
+            .WithTitle("Fang-Check")
             .WithColor(Color.Red)
-            .WithDescription($"**{result.RequestedPokemonName}** may not be caught because this evolution line already appears in the run.")
-            .AddField("Pokemon", result.RequestedPokemonName, true)
-            .AddField("Result", "Blocked", true)
-            .AddField("Matched Pokemon", match.PokemonName, true)
-            .AddField("Route", match.Route, true)
-            .AddField("Player", match.PlayerName, true)
-            .AddField("Status", match.Status, true)
+            .WithDescription($"⛔ **{result.RequestedPokemonName}** ist gesperrt.")
+            .AddField("Fund", $"{match.PokemonName} · {match.Route} · {match.PlayerName} · {FormatCatchCheckStatus(match.Status)}")
             .Build();
     }
 
@@ -474,6 +467,17 @@ public sealed class EmbedFactory
         return string.Join(
             Environment.NewLine + Environment.NewLine,
             blocks);
+    }
+
+    private static string FormatCatchCheckStatus(string status)
+    {
+        return status switch
+        {
+            "Dead" => "Tot",
+            "Team" => "Team",
+            "Box" => "Box",
+            _ => status,
+        };
     }
 
     private IReadOnlyList<string> CreateStatusBlocks(SoulLinkRun run)

--- a/PokeSoulLinkBot/Bot/Program.cs
+++ b/PokeSoulLinkBot/Bot/Program.cs
@@ -106,15 +106,13 @@ internal sealed class Program
         {
             try
             {
-                Log.Information("Registering global slash commands.");
                 var definitions = slashCommandRouter.GetDefinitions();
                 foreach (var definition in definitions)
                 {
                     Log.Debug("Prepared slash command definition {CommandName}.", definition.Name.Value);
                 }
 
-                await client.BulkOverwriteGlobalApplicationCommandsAsync(definitions.ToArray());
-                Log.Information("Registered {CommandCount} global slash commands.", definitions.Count);
+                await RegisterSlashCommandsAsync(definitions);
 
                 Log.Information("Initializing game data catalog.");
                 await gameDataCatalogService.InitializeAsync();
@@ -127,6 +125,32 @@ internal sealed class Program
             catch (Exception exception)
             {
                 Log.Error(exception, "Ready startup failed.");
+            }
+        }
+
+        async Task RegisterSlashCommandsAsync(IReadOnlyCollection<ApplicationCommandProperties> definitions)
+        {
+            var commandDefinitions = definitions.ToArray();
+
+            Log.Information("Registering {CommandCount} global slash commands.", commandDefinitions.Length);
+            await client.BulkOverwriteGlobalApplicationCommandsAsync(commandDefinitions);
+            Log.Information("Registered {CommandCount} global slash commands.", commandDefinitions.Length);
+
+            foreach (var guild in client.Guilds)
+            {
+                Log.Information(
+                    "Registering {CommandCount} slash commands for guild {GuildName} ({GuildId}).",
+                    commandDefinitions.Length,
+                    guild.Name,
+                    guild.Id);
+
+                await guild.BulkOverwriteApplicationCommandAsync(commandDefinitions);
+
+                Log.Information(
+                    "Registered {CommandCount} slash commands for guild {GuildName} ({GuildId}).",
+                    commandDefinitions.Length,
+                    guild.Name,
+                    guild.Id);
             }
         }
     }

--- a/PokeSoulLinkBot/Bot/Program.cs
+++ b/PokeSoulLinkBot/Bot/Program.cs
@@ -67,6 +67,7 @@ internal sealed class Program
 
         var runStore = new RunStore(filePath);
         var runService = new RunService(runStore);
+        var catchEligibilityService = new CatchEligibilityService(runService, pokedexService);
         var embedFactory = new EmbedFactory();
         var embedImageFactory = new EmbedImageFactory(resourcesDirectoryPath);
 
@@ -75,6 +76,7 @@ internal sealed class Program
             new RunStartCommand(runService, embedFactory, embedImageFactory, gameDataCatalogService),
             new RunEndCommand(runService, embedFactory, embedImageFactory),
             new CatchCommand(runService, embedFactory, embedImageFactory, pokemonLookupService, gameDataCatalogService),
+            new CatchCheckCommand(catchEligibilityService, embedFactory),
             new DeathCommand(runService, embedFactory, embedImageFactory),
             new RouteDeathCommand(runService, embedFactory, embedImageFactory, gameDataCatalogService),
             new StatusCommand(runService, embedFactory, embedImageFactory, pokemonLookupService),

--- a/PokeSoulLinkBot/Core/Models/CatchCheckMatch.cs
+++ b/PokeSoulLinkBot/Core/Models/CatchCheckMatch.cs
@@ -1,0 +1,27 @@
+namespace PokeSoulLinkBot.Core.Models;
+
+/// <summary>
+/// Represents an existing catch that blocks a new Pokémon catch.
+/// </summary>
+public sealed class CatchCheckMatch
+{
+    /// <summary>
+    /// Gets or sets the route where the matching Pokémon was caught.
+    /// </summary>
+    public string Route { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the player who caught the matching Pokémon.
+    /// </summary>
+    public string PlayerName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the matching Pokémon name.
+    /// </summary>
+    public string PokemonName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the current status of the matching Pokémon.
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+}

--- a/PokeSoulLinkBot/Core/Models/CatchCheckResult.cs
+++ b/PokeSoulLinkBot/Core/Models/CatchCheckResult.cs
@@ -1,0 +1,22 @@
+namespace PokeSoulLinkBot.Core.Models;
+
+/// <summary>
+/// Describes whether a Pokémon may still be caught in an active run.
+/// </summary>
+public sealed class CatchCheckResult
+{
+    /// <summary>
+    /// Gets or sets the requested Pokémon name.
+    /// </summary>
+    public string RequestedPokemonName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the Pokémon may be caught.
+    /// </summary>
+    public bool IsAllowed { get; set; }
+
+    /// <summary>
+    /// Gets or sets the existing catch that blocks this Pokémon, if any.
+    /// </summary>
+    public CatchCheckMatch? Match { get; set; }
+}


### PR DESCRIPTION
Ticket: https://github.com/mpiechot/PokemonSoulLinkDiscord/issues/17

## Summary
- Add `/catch-check` to check whether a Pokémon may still be caught in the active run.
- Compare requested Pokémon against existing catches through their evolution lines, including dead catches.
- Report blocking catch details with route, player, Pokémon, and status in a short German response.
- Register slash commands per connected guild as well as globally so new commands become available immediately after a bot restart.
- Tolerate unresolved legacy/stored catch names so unrelated stored typos do not break new checks.

## Verification
- `dotnet test PokeSoulLinkBot.Tests\PokeSoulLinkBot.Tests.csproj`
- `dotnet test PokeSoulLinkBot.Tests\PokeSoulLinkBot.Tests.csproj -p:OutputPath=..\.codex-test-bl010-refresh\`
- `dotnet test PokeSoulLinkBot.Tests\PokeSoulLinkBot.Tests.csproj -p:OutputPath=..\.codex-test-bl010-stored-name\`
- `dotnet test PokeSoulLinkBot.Tests\PokeSoulLinkBot.Tests.csproj -p:OutputPath=..\.codex-test-bl010-output\`