### PR TITLE
Harden slash command responses and data lookups

### DIFF
--- a/PokeSoulLinkBot.Tests/EmbedFactoryStatusTests.cs
+++ b/PokeSoulLinkBot.Tests/EmbedFactoryStatusTests.cs
@@ -125,6 +125,7 @@ public sealed class EmbedFactoryStatusTests
         Assert.Contains("**Dead**", fullMessage, StringComparison.Ordinal);
         Assert.DoesNotContain("(continued)", fullMessage, StringComparison.Ordinal);
         Assert.DoesNotContain("...```", fullMessage, StringComparison.Ordinal);
+        Assert.All(messages, message => Assert.InRange(message.Length, 1, 2000));
         for (var routeIndex = 1; routeIndex <= 80; routeIndex++)
         {
             Assert.Contains($"route-{routeIndex:000}", fullMessage, StringComparison.Ordinal);

--- a/PokeSoulLinkBot.Tests/PokeApiGameDataCatalogServiceTests.cs
+++ b/PokeSoulLinkBot.Tests/PokeApiGameDataCatalogServiceTests.cs
@@ -41,6 +41,23 @@ public sealed class PokeApiGameDataCatalogServiceTests
     }
 
     [Fact]
+    public async Task BackgroundRefresh_ShouldNotSaveEmptyCatalogWhenRootFetchFails()
+    {
+        var cacheFilePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "game-data-catalog.json");
+        var handler = new FailingHttpMessageHandler();
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://pokeapi.co/api/v2/"),
+        };
+        var service = new PokeApiGameDataCatalogService(httpClient, cacheFilePath);
+
+        await service.GetEditionsAsync();
+        await WaitForRequestCountAsync(handler, 2);
+
+        Assert.False(File.Exists(cacheFilePath));
+    }
+
+    [Fact]
     public async Task GetEditionsAsync_ShouldUseCachedCatalog()
     {
         var cacheFilePath = CreateCacheFile(new GameDataCatalog
@@ -183,6 +200,21 @@ public sealed class PokeApiGameDataCatalogServiceTests
         throw new InvalidOperationException("Game data catalog was not refreshed in time.");
     }
 
+    private static async Task WaitForRequestCountAsync(FailingHttpMessageHandler handler, int requestCount)
+    {
+        for (var attempt = 0; attempt < 20; attempt++)
+        {
+            if (handler.RequestCount >= requestCount)
+            {
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+        }
+
+        throw new InvalidOperationException("Expected HTTP requests were not sent in time.");
+    }
+
     private sealed class BlockingHttpMessageHandler : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(
@@ -199,10 +231,16 @@ public sealed class PokeApiGameDataCatalogServiceTests
 
     private sealed class FailingHttpMessageHandler : HttpMessageHandler
     {
+        private int requestCount;
+
+        public int RequestCount => Volatile.Read(ref this.requestCount);
+
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
+            Interlocked.Increment(ref this.requestCount);
+
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError));
         }
     }

--- a/PokeSoulLinkBot.Tests/PokeApiPokemonLookupServiceTests.cs
+++ b/PokeSoulLinkBot.Tests/PokeApiPokemonLookupServiceTests.cs
@@ -1,0 +1,116 @@
+using System.Net;
+using System.Text;
+using PokeSoulLinkBot.Application.Interfaces;
+using PokeSoulLinkBot.Application.Services;
+using Xunit;
+
+namespace PokeSoulLinkBot.Tests;
+
+public sealed class PokeApiPokemonLookupServiceTests
+{
+    [Fact]
+    public async Task GetPokemonInfoAsync_ShouldCacheSuccessfulLookupsByResolvedName()
+    {
+        var handler = new CountingPokemonHttpMessageHandler();
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://pokeapi.co/api/v2/"),
+        };
+        var service = new PokeApiPokemonLookupService(httpClient, new StubPokemonNameResolver("bulbasaur"));
+
+        var firstInfo = await service.GetPokemonInfoAsync("Bisasam");
+        var secondInfo = await service.GetPokemonInfoAsync("Bulbasaur");
+
+        Assert.NotNull(firstInfo);
+        Assert.Same(firstInfo, secondInfo);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task GetPokemonInfoAsync_ShouldRetryTransientHttpFailures()
+    {
+        var handler = new TransientThenSuccessfulPokemonHttpMessageHandler();
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://pokeapi.co/api/v2/"),
+        };
+        var service = new PokeApiPokemonLookupService(httpClient, new StubPokemonNameResolver("bulbasaur"));
+
+        var pokemonInfo = await service.GetPokemonInfoAsync("Bulbasaur");
+
+        Assert.NotNull(pokemonInfo);
+        Assert.Equal(2, handler.RequestCount);
+    }
+
+    private static HttpResponseMessage CreatePokemonResponse()
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """
+                {
+                  "sprites": {
+                    "other": {
+                      "official-artwork": {
+                        "front_default": "https://img.example/bulbasaur.png"
+                      }
+                    }
+                  },
+                  "types": [
+                    {
+                      "slot": 1,
+                      "type": { "name": "grass" }
+                    }
+                  ]
+                }
+                """,
+                Encoding.UTF8,
+                "application/json"),
+        };
+    }
+
+    private sealed class StubPokemonNameResolver : IPokemonNameResolver
+    {
+        private readonly string resolvedName;
+
+        public StubPokemonNameResolver(string resolvedName)
+        {
+            this.resolvedName = resolvedName;
+        }
+
+        public Task<string> ResolvePokemonNameAsync(string pokemonName)
+        {
+            return Task.FromResult(this.resolvedName);
+        }
+    }
+
+    private sealed class CountingPokemonHttpMessageHandler : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            this.RequestCount++;
+
+            return Task.FromResult(CreatePokemonResponse());
+        }
+    }
+
+    private sealed class TransientThenSuccessfulPokemonHttpMessageHandler : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            this.RequestCount++;
+
+            return Task.FromResult(this.RequestCount == 1
+                ? new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                : CreatePokemonResponse());
+        }
+    }
+}

--- a/PokeSoulLinkBot.Tests/PokeApiPokemonNameResolverTests.cs
+++ b/PokeSoulLinkBot.Tests/PokeApiPokemonNameResolverTests.cs
@@ -1,0 +1,51 @@
+using System.Net;
+using System.Text;
+using PokeSoulLinkBot.Application.Services;
+using Xunit;
+
+namespace PokeSoulLinkBot.Tests;
+
+public sealed class PokeApiPokemonNameResolverTests
+{
+    [Fact]
+    public async Task ResolvePokemonNameAsync_ShouldCacheResolvedDirectNames()
+    {
+        var handler = new CountingNameResolverHttpMessageHandler();
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://pokeapi.co/api/v2/"),
+        };
+        var resolver = new PokeApiPokemonNameResolver(httpClient);
+
+        var firstName = await resolver.ResolvePokemonNameAsync("Bulbasaur");
+        var secondName = await resolver.ResolvePokemonNameAsync("bulbasaur");
+
+        Assert.Equal("bulbasaur", firstName);
+        Assert.Equal("bulbasaur", secondName);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    private sealed class CountingNameResolverHttpMessageHandler : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            this.RequestCount++;
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {
+                      "name": "bulbasaur"
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+        }
+    }
+}

--- a/PokeSoulLinkBot.Tests/SlashCommandResponsePatternTests.cs
+++ b/PokeSoulLinkBot.Tests/SlashCommandResponsePatternTests.cs
@@ -40,6 +40,49 @@ public sealed class SlashCommandResponsePatternTests
         Assert.Empty(violations);
     }
 
+    [Fact]
+    public void SlashCommandHandlers_ShouldUseCentralResponseHelperForFollowupResponses()
+    {
+        var commandsDirectory = Path.Combine(GetRepositoryRoot(), "PokeSoulLinkBot", "Bot", "Commands");
+        var commandFiles = Directory.GetFiles(commandsDirectory, "*Command.cs")
+            .Where(file => Path.GetFileName(file) != "ISlashCommand.cs");
+        var violations = new List<string>();
+
+        foreach (var commandFile in commandFiles)
+        {
+            var source = File.ReadAllText(commandFile);
+            var handleAsyncBody = ExtractMethodBody(source, "public async Task HandleAsync(SocketSlashCommand command)");
+
+            if (handleAsyncBody.Contains(".FollowupAsync(", StringComparison.Ordinal)
+                || handleAsyncBody.Contains(".FollowupWithFileAsync(", StringComparison.Ordinal))
+            {
+                violations.Add(Path.GetFileName(commandFile));
+            }
+        }
+
+        Assert.Empty(violations);
+    }
+
+    [Fact]
+    public void CatchCommand_ShouldUsePagedStatusFollowups()
+    {
+        var source = ReadSourceFile("PokeSoulLinkBot", "Bot", "Commands", "CatchCommand.cs");
+        var handleAsyncBody = ExtractMethodBody(source, "public async Task HandleAsync(SocketSlashCommand command)");
+
+        Assert.Contains("this.embedFactory.CreateStatusMessages(activeRun)", handleAsyncBody, StringComparison.Ordinal);
+        Assert.Contains("SlashCommandResponse.SendFollowupsAsync(command, statusMessages)", handleAsyncBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("CreateStatusMessage(activeRun)", handleAsyncBody, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Router_ShouldGuardErrorResponseFailures()
+    {
+        var routerSource = ReadSourceFile("PokeSoulLinkBot", "Bot", "SlashCommandRouter.cs");
+
+        Assert.Contains("TrySendErrorResponseAsync(command, errorEmbed, exception)", routerSource, StringComparison.Ordinal);
+        Assert.Contains("Could not send error response for slash command", routerSource, StringComparison.Ordinal);
+    }
+
     private static string ReadSourceFile(params string[] pathParts)
     {
         return File.ReadAllText(Path.Combine(new[] { GetRepositoryRoot() }.Concat(pathParts).ToArray()));

--- a/PokeSoulLinkBot/Application/Interfaces/IPokemonLookupService.cs
+++ b/PokeSoulLinkBot/Application/Interfaces/IPokemonLookupService.cs
@@ -3,14 +3,14 @@ using PokeSoulLinkBot.Core.Models;
 namespace PokeSoulLinkBot.Application.Interfaces;
 
 /// <summary>
-/// Provides Pokémon image lookup functionality.
+/// Provides Pokémon metadata lookup functionality.
 /// </summary>
 public interface IPokemonLookupService
 {
     /// <summary>
-    /// Gets the image URL for the specified Pokémon.
+    /// Gets metadata for the specified Pokémon.
     /// </summary>
     /// <param name="pokemonName">The Pokémon name.</param>
-    /// <returns>The image URL if found; otherwise, <see langword="null"/>.</returns>
+    /// <returns>The Pokémon metadata if found; otherwise, <see langword="null"/>.</returns>
     Task<PokemonInfo?> GetPokemonInfoAsync(string pokemonName);
 }

--- a/PokeSoulLinkBot/Application/Services/HttpRequestHelper.cs
+++ b/PokeSoulLinkBot/Application/Services/HttpRequestHelper.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using System.Text.Json;
+using Serilog;
+
+namespace PokeSoulLinkBot.Application.Services;
+
+internal static class HttpRequestHelper
+{
+    private const int MaxAttempts = 2;
+
+    public static Task<HttpResponseMessage> GetAsync(HttpClient httpClient, string requestUri)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentException.ThrowIfNullOrWhiteSpace(requestUri);
+
+        return GetWithRetryAsync(() => httpClient.GetAsync(requestUri), requestUri);
+    }
+
+    public static Task<HttpResponseMessage> GetAsync(HttpClient httpClient, Uri requestUri)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(requestUri);
+
+        return GetWithRetryAsync(() => httpClient.GetAsync(requestUri), requestUri.ToString());
+    }
+
+    public static async Task<T?> GetFromJsonAsync<T>(
+        HttpClient httpClient,
+        string requestUri,
+        JsonSerializerOptions jsonSerializerOptions)
+    {
+        ArgumentNullException.ThrowIfNull(jsonSerializerOptions);
+
+        using var response = await GetAsync(httpClient, requestUri);
+        if (!response.IsSuccessStatusCode)
+        {
+            return default;
+        }
+
+        await using var responseStream = await response.Content.ReadAsStreamAsync();
+        return await JsonSerializer.DeserializeAsync<T>(responseStream, jsonSerializerOptions);
+    }
+
+    public static async Task<string> GetStringAsync(HttpClient httpClient, Uri requestUri)
+    {
+        using var response = await GetAsync(httpClient, requestUri);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadAsStringAsync();
+    }
+
+    private static async Task<HttpResponseMessage> GetWithRetryAsync(
+        Func<Task<HttpResponseMessage>> sendAsync,
+        string requestUri)
+    {
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+        {
+            try
+            {
+                var response = await sendAsync();
+                if (!IsTransientStatusCode(response.StatusCode) || attempt == MaxAttempts)
+                {
+                    return response;
+                }
+
+                Log.Warning(
+                    "HTTP GET {RequestUri} returned transient status {StatusCode} on attempt {Attempt}/{MaxAttempts}. Retrying.",
+                    requestUri,
+                    response.StatusCode,
+                    attempt,
+                    MaxAttempts);
+                response.Dispose();
+            }
+            catch (Exception exception) when (IsTransientException(exception) && attempt < MaxAttempts)
+            {
+                Log.Warning(
+                    exception,
+                    "HTTP GET {RequestUri} failed on attempt {Attempt}/{MaxAttempts}. Retrying.",
+                    requestUri,
+                    attempt,
+                    MaxAttempts);
+            }
+
+            await Task.Delay(GetRetryDelay(attempt));
+        }
+
+        throw new InvalidOperationException("HTTP retry loop exited unexpectedly.");
+    }
+
+    private static bool IsTransientException(Exception exception)
+    {
+        return exception is HttpRequestException or TaskCanceledException;
+    }
+
+    private static bool IsTransientStatusCode(HttpStatusCode statusCode)
+    {
+        return statusCode is HttpStatusCode.RequestTimeout or HttpStatusCode.TooManyRequests
+            || (int)statusCode >= 500;
+    }
+
+    private static TimeSpan GetRetryDelay(int attempt)
+    {
+        return TimeSpan.FromMilliseconds(100 * attempt);
+    }
+}

--- a/PokeSoulLinkBot/Application/Services/HttpRequestHelper.cs
+++ b/PokeSoulLinkBot/Application/Services/HttpRequestHelper.cs
@@ -32,10 +32,7 @@ internal static class HttpRequestHelper
         ArgumentNullException.ThrowIfNull(jsonSerializerOptions);
 
         using var response = await GetAsync(httpClient, requestUri);
-        if (!response.IsSuccessStatusCode)
-        {
-            return default;
-        }
+        response.EnsureSuccessStatusCode();
 
         await using var responseStream = await response.Content.ReadAsStreamAsync();
         return await JsonSerializer.DeserializeAsync<T>(responseStream, jsonSerializerOptions);

--- a/PokeSoulLinkBot/Application/Services/PokeApiGameDataCatalogService.cs
+++ b/PokeSoulLinkBot/Application/Services/PokeApiGameDataCatalogService.cs
@@ -1,4 +1,3 @@
-using System.Net.Http.Json;
 using System.Text.Json;
 using PokeSoulLinkBot.Application.Interfaces;
 using PokeSoulLinkBot.Core.Dtos;
@@ -199,7 +198,10 @@ public sealed class PokeApiGameDataCatalogService : IGameDataCatalogService
     {
         Log.Information("Using game data catalog source PokeAPI for refresh.");
         Log.Debug("Fetching Pokemon versions from PokeAPI.");
-        var versionList = await this.httpClient.GetFromJsonAsync<NamedApiResourceListDto>("version?limit=10000", JsonOptions);
+        var versionList = await HttpRequestHelper.GetFromJsonAsync<NamedApiResourceListDto>(
+            this.httpClient,
+            "version?limit=10000",
+            JsonOptions);
         var versions = versionList?.Results ?? new List<NamedApiResourceDto>();
         var editionsByName = versions
             .Where(version => !string.IsNullOrWhiteSpace(version.Name))
@@ -223,7 +225,10 @@ public sealed class PokeApiGameDataCatalogService : IGameDataCatalogService
     private async Task AddEncounterRoutesAsync(Dictionary<string, GameEditionInfo> editionsByName)
     {
         Log.Debug("Fetching Pokemon location areas from PokeAPI.");
-        var locationAreaList = await this.httpClient.GetFromJsonAsync<NamedApiResourceListDto>("location-area?limit=10000", JsonOptions);
+        var locationAreaList = await HttpRequestHelper.GetFromJsonAsync<NamedApiResourceListDto>(
+            this.httpClient,
+            "location-area?limit=10000",
+            JsonOptions);
         var locationAreas = locationAreaList?.Results ?? new List<NamedApiResourceDto>();
         var routeNamesByVersion = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
 
@@ -296,7 +301,8 @@ public sealed class PokeApiGameDataCatalogService : IGameDataCatalogService
     {
         try
         {
-            return await this.httpClient.GetFromJsonAsync<LocationAreaDto>(
+            return await HttpRequestHelper.GetFromJsonAsync<LocationAreaDto>(
+                this.httpClient,
                 $"location-area/{locationAreaName}",
                 JsonOptions);
         }

--- a/PokeSoulLinkBot/Application/Services/PokeApiPokedexService.cs
+++ b/PokeSoulLinkBot/Application/Services/PokeApiPokedexService.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using PokeSoulLinkBot.Application.Interfaces;
 using PokeSoulLinkBot.Core.Dtos;
 using PokeSoulLinkBot.Core.Models;
+using Serilog;
 
 namespace PokeSoulLinkBot.Application.Services;
 
@@ -64,7 +65,10 @@ public sealed class PokeApiPokedexService : IPokedexService
 
         if (string.IsNullOrWhiteSpace(imageUrl))
         {
-            Console.WriteLine($"Pokédex image lookup found no image for '{pokemonName}' using '{normalizedPokemonName}'.");
+            Log.Debug(
+                "Pokedex image lookup found no image for '{PokemonName}' resolved as '{ResolvedPokemonName}'.",
+                pokemonName,
+                normalizedPokemonName);
         }
 
         return new PokedexEntry
@@ -340,7 +344,7 @@ public sealed class PokeApiPokedexService : IPokedexService
 
         try
         {
-            using var response = await this.httpClient.GetAsync(requestUri);
+            using var response = await HttpRequestHelper.GetAsync(this.httpClient, requestUri);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/PokeSoulLinkBot/Application/Services/PokeApiPokemonLookupService.cs
+++ b/PokeSoulLinkBot/Application/Services/PokeApiPokemonLookupService.cs
@@ -1,7 +1,9 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using PokeSoulLinkBot.Application.Interfaces;
 using PokeSoulLinkBot.Core.Dtos;
 using PokeSoulLinkBot.Core.Models;
+using Serilog;
 
 namespace PokeSoulLinkBot.Application.Services;
 
@@ -15,6 +17,8 @@ public sealed class PokeApiPokemonLookupService : IPokemonLookupService
 
     private readonly HttpClient httpClient;
     private readonly IPokemonNameResolver pokemonNameResolver;
+    private readonly ConcurrentDictionary<string, PokemonInfo> pokemonInfoCache =
+        new ConcurrentDictionary<string, PokemonInfo>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PokeApiPokemonLookupService"/> class.
@@ -45,8 +49,14 @@ public sealed class PokeApiPokemonLookupService : IPokemonLookupService
         }
         catch (InvalidOperationException exception)
         {
-            Console.WriteLine($"Pokémon name lookup failed for '{pokemonName}': {exception.Message}");
+            Log.Warning(exception, "Pokemon name lookup failed for '{PokemonName}'.", pokemonName);
             return null;
+        }
+
+        if (this.pokemonInfoCache.TryGetValue(resolvedName, out var cachedInfo))
+        {
+            Log.Debug("Using cached Pokemon info for '{PokemonName}' resolved as '{ResolvedName}'.", pokemonName, resolvedName);
+            return cachedInfo;
         }
 
         var requestUri = $"pokemon/{Uri.EscapeDataString(resolvedName)}";
@@ -54,11 +64,15 @@ public sealed class PokeApiPokemonLookupService : IPokemonLookupService
 
         try
         {
-            using var response = await this.httpClient.GetAsync(requestUri);
+            using var response = await HttpRequestHelper.GetAsync(this.httpClient, requestUri);
 
             if (!response.IsSuccessStatusCode)
             {
-                Console.WriteLine($"Pokémon image lookup failed for '{pokemonName}' using '{resolvedName}': {response.StatusCode}");
+                Log.Warning(
+                    "Pokemon lookup failed for '{PokemonName}' resolved as '{ResolvedName}'. StatusCode={StatusCode}.",
+                    pokemonName,
+                    resolvedName,
+                    response.StatusCode);
                 return null;
             }
 
@@ -67,13 +81,20 @@ public sealed class PokeApiPokemonLookupService : IPokemonLookupService
         }
         catch (Exception exception) when (exception is HttpRequestException or JsonException or TaskCanceledException)
         {
-            Console.WriteLine($"Pokémon image lookup failed for '{pokemonName}' using '{resolvedName}': {exception.Message}");
+            Log.Warning(
+                exception,
+                "Pokemon lookup failed for '{PokemonName}' resolved as '{ResolvedName}'.",
+                pokemonName,
+                resolvedName);
             return null;
         }
 
         if (dto == null)
         {
-            Console.WriteLine($"Pokémon image lookup returned no data for '{pokemonName}' using '{resolvedName}'.");
+            Log.Warning(
+                "Pokemon lookup returned no data for '{PokemonName}' resolved as '{ResolvedName}'.",
+                pokemonName,
+                resolvedName);
             return null;
         }
 
@@ -87,13 +108,19 @@ public sealed class PokeApiPokemonLookupService : IPokemonLookupService
 
         if (string.IsNullOrWhiteSpace(imageUrl))
         {
-            Console.WriteLine($"Pokémon image lookup found no image for '{pokemonName}' using '{resolvedName}'.");
+            Log.Debug(
+                "Pokemon lookup found no image for '{PokemonName}' resolved as '{ResolvedName}'.",
+                pokemonName,
+                resolvedName);
         }
 
-        return new PokemonInfo
+        var pokemonInfo = new PokemonInfo
         {
             ImageUrl = imageUrl,
             Types = types,
         };
+
+        this.pokemonInfoCache.TryAdd(resolvedName, pokemonInfo);
+        return pokemonInfo;
     }
 }

--- a/PokeSoulLinkBot/Application/Services/PokeApiPokemonNameResolver.cs
+++ b/PokeSoulLinkBot/Application/Services/PokeApiPokemonNameResolver.cs
@@ -1,8 +1,10 @@
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using PokeSoulLinkBot.Application.Interfaces;
 using PokeSoulLinkBot.Core.Dtos;
+using Serilog;
 
 namespace PokeSoulLinkBot.Application.Services;
 
@@ -18,6 +20,9 @@ public sealed class PokeApiPokemonNameResolver : IPokemonNameResolver
 
     private readonly SemaphoreSlim indexLock = new SemaphoreSlim(1, 1);
     private readonly HttpClient httpClient;
+    private readonly ConcurrentDictionary<string, string> resolvedNameCache =
+        new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
     private IReadOnlyDictionary<string, string>? localizedNameIndex;
 
     /// <summary>
@@ -38,17 +43,27 @@ public sealed class PokeApiPokemonNameResolver : IPokemonNameResolver
         ArgumentException.ThrowIfNullOrWhiteSpace(pokemonName);
 
         var normalizedName = this.NormalizePokemonName(pokemonName);
+        var lookupKey = this.CreateLookupKey(pokemonName);
+        if (this.resolvedNameCache.TryGetValue(lookupKey, out var cachedName))
+        {
+            return cachedName;
+        }
+
         var directName = await this.TryResolveDirectPokemonNameAsync(normalizedName);
 
         if (!string.IsNullOrWhiteSpace(directName))
         {
+            this.resolvedNameCache.TryAdd(lookupKey, directName);
             return directName;
         }
 
         var nameIndex = await this.GetLocalizedNameIndexAsync();
-        return nameIndex.TryGetValue(this.CreateLookupKey(pokemonName), out var resolvedName)
-            ? resolvedName
+        var resolvedName = nameIndex.TryGetValue(lookupKey, out var indexedName)
+            ? indexedName
             : normalizedName;
+
+        this.resolvedNameCache.TryAdd(lookupKey, resolvedName);
+        return resolvedName;
     }
 
     private void AddSpeciesNames(Dictionary<string, string> index, PokemonSpeciesDto species)
@@ -145,7 +160,7 @@ public sealed class PokeApiPokemonNameResolver : IPokemonNameResolver
         }
         catch (InvalidOperationException exception)
         {
-            Console.WriteLine($"Direct Pokémon name lookup failed for '{pokemonName}': {exception.Message}");
+            Log.Debug(exception, "Direct Pokemon name lookup failed for '{PokemonName}'.", pokemonName);
             return null;
         }
     }
@@ -204,7 +219,7 @@ public sealed class PokeApiPokemonNameResolver : IPokemonNameResolver
     {
         try
         {
-            using var response = await this.httpClient.GetAsync(requestUri);
+            using var response = await HttpRequestHelper.GetAsync(this.httpClient, requestUri);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/PokeSoulLinkBot/Application/Services/PokemonDbArenaInfoService.cs
+++ b/PokeSoulLinkBot/Application/Services/PokemonDbArenaInfoService.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Text.RegularExpressions;
 using PokeSoulLinkBot.Application.Interfaces;
 using PokeSoulLinkBot.Core.Models;
+using Serilog;
 
 namespace PokeSoulLinkBot.Application.Services;
 
@@ -129,7 +130,10 @@ public sealed class PokemonDbArenaInfoService : IArenaInfoService
             }
             catch (Exception exception) when (exception is HttpRequestException or InvalidOperationException or TaskCanceledException)
             {
-                Console.WriteLine($"Arena data warm-up failed for '{representativeEdition.Key}': {exception.Message}");
+                Log.Warning(
+                    exception,
+                    "Arena data warm-up failed for edition '{Edition}'.",
+                    representativeEdition.Key);
             }
         }
     }
@@ -189,7 +193,7 @@ public sealed class PokemonDbArenaInfoService : IArenaInfoService
         }
 
         var sourceUri = new Uri(BaseUri, $"{sourceSlug}/gymleaders-elitefour");
-        var html = await this.httpClient.GetStringAsync(sourceUri);
+        var html = await HttpRequestHelper.GetStringAsync(this.httpClient, sourceUri);
         var arenaInfos = ParseArenaInfos(html, edition);
 
         if (arenaInfos.Count == 0)

--- a/PokeSoulLinkBot/Bot/Commands/CatchCommand.cs
+++ b/PokeSoulLinkBot/Bot/Commands/CatchCommand.cs
@@ -86,8 +86,8 @@ public class CatchCommand : ISlashCommand
 
         await SlashCommandResponse.SendFileAsync(command, image.FileAttachment, embed: catchEmbed);
 
-        var statusMessage = this.embedFactory.CreateStatusMessage(activeRun);
-        await command.FollowupAsync(statusMessage);
+        var statusMessages = this.embedFactory.CreateStatusMessages(activeRun);
+        await SlashCommandResponse.SendFollowupsAsync(command, statusMessages);
     }
 
     /// <inheritdoc />

--- a/PokeSoulLinkBot/Bot/Commands/StatusCommand.cs
+++ b/PokeSoulLinkBot/Bot/Commands/StatusCommand.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Discord;
 using Discord.WebSocket;
 using PokeSoulLinkBot.Application.Interfaces;
@@ -12,6 +13,8 @@ namespace PokeSoulLinkBot.Bot.Commands;
 /// </summary>
 public class StatusCommand : ISlashCommand
 {
+    private const int MaxParallelPokemonTypeLookups = 4;
+
     private readonly IRunService runService;
     private readonly EmbedFactory embedFactory;
     private readonly EmbedImageFactory embedImageFactory;
@@ -66,26 +69,58 @@ public class StatusCommand : ISlashCommand
         var embed = this.embedFactory.CreateRunSummaryEmbed("Run Status", activeRun, image.AttachmentUrl);
         await SlashCommandResponse.SendFileAsync(command, image.FileAttachment, text: messages[0], embed: embed);
 
-        foreach (var message in messages.Skip(1))
-        {
-            await command.FollowupAsync(message);
-        }
+        await SlashCommandResponse.SendFollowupsAsync(command, messages.Skip(1));
     }
 
     private async Task EnrichMissingPokemonTypesAsync(SoulLinkRun run)
     {
-        foreach (var entry in run.LinkGroups.SelectMany(group => group.Entries))
-        {
-            if (entry.Types.Count > 0)
-            {
-                continue;
-            }
+        var entriesWithoutTypes = run.LinkGroups
+            .SelectMany(group => group.Entries)
+            .Where(entry => entry.Types.Count == 0)
+            .ToList();
 
-            var pokemonInfo = await this.pokemonLookupService.GetPokemonInfoAsync(entry.PokemonName);
+        if (entriesWithoutTypes.Count == 0)
+        {
+            return;
+        }
+
+        var typesByPokemonName = new ConcurrentDictionary<string, IReadOnlyList<string>>(
+            StringComparer.OrdinalIgnoreCase);
+        using var lookupLimiter = new SemaphoreSlim(MaxParallelPokemonTypeLookups, MaxParallelPokemonTypeLookups);
+        var lookupTasks = entriesWithoutTypes
+            .Select(entry => entry.PokemonName)
+            .Where(pokemonName => !string.IsNullOrWhiteSpace(pokemonName))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(pokemonName => this.LookupPokemonTypesAsync(pokemonName, typesByPokemonName, lookupLimiter));
+
+        await Task.WhenAll(lookupTasks);
+
+        foreach (var entry in entriesWithoutTypes)
+        {
+            if (typesByPokemonName.TryGetValue(entry.PokemonName, out var pokemonTypes))
+            {
+                entry.Types = pokemonTypes.ToList();
+            }
+        }
+    }
+
+    private async Task LookupPokemonTypesAsync(
+        string pokemonName,
+        ConcurrentDictionary<string, IReadOnlyList<string>> typesByPokemonName,
+        SemaphoreSlim lookupLimiter)
+    {
+        await lookupLimiter.WaitAsync();
+        try
+        {
+            var pokemonInfo = await this.pokemonLookupService.GetPokemonInfoAsync(pokemonName);
             if (pokemonInfo?.Types.Count > 0)
             {
-                entry.Types = pokemonInfo.Types.ToList();
+                typesByPokemonName.TryAdd(pokemonName, pokemonInfo.Types);
             }
+        }
+        finally
+        {
+            lookupLimiter.Release();
         }
     }
 }

--- a/PokeSoulLinkBot/Bot/Commands/SwapCommand.cs
+++ b/PokeSoulLinkBot/Bot/Commands/SwapCommand.cs
@@ -59,11 +59,12 @@ public sealed class SwapCommand : ISlashCommand
         var boxRoute = CommandOptionHelper.GetRequiredStringOption(command, "box-route").ToLowerInvariant().Trim();
 
         var activeRun = this.runService.SwapRoute(guildId, teamRoute, boxRoute);
-        var message = this.embedFactory.CreateTeamMessage(activeRun);
+        var messages = this.embedFactory.CreateTeamMessages(activeRun);
         var image = this.embedImageFactory.CreateSwapImage();
         var embed = this.embedFactory.CreateRunSummaryEmbed("Team Swapped", activeRun, image.AttachmentUrl);
 
-        await SlashCommandResponse.SendFileAsync(command, image.FileAttachment, text: message, embed: embed);
+        await SlashCommandResponse.SendFileAsync(command, image.FileAttachment, text: messages[0], embed: embed);
+        await SlashCommandResponse.SendFollowupsAsync(command, messages.Skip(1));
     }
 
     /// <inheritdoc />

--- a/PokeSoulLinkBot/Bot/Commands/TeamCommand.cs
+++ b/PokeSoulLinkBot/Bot/Commands/TeamCommand.cs
@@ -53,9 +53,6 @@ public class TeamCommand : ISlashCommand
         var messages = this.embedFactory.CreateTeamMessages(activeRun);
         await SlashCommandResponse.SendAsync(command, messages[0]);
 
-        foreach (var message in messages.Skip(1))
-        {
-            await command.FollowupAsync(message);
-        }
+        await SlashCommandResponse.SendFollowupsAsync(command, messages.Skip(1));
     }
 }

--- a/PokeSoulLinkBot/Bot/Commands/UseCommand.cs
+++ b/PokeSoulLinkBot/Bot/Commands/UseCommand.cs
@@ -73,9 +73,6 @@ public class UseCommand : ISlashCommand
         var embed = this.embedFactory.CreateRunSummaryEmbed("Active Team Updated", activeRun, image.AttachmentUrl);
         await SlashCommandResponse.SendFileAsync(command, image.FileAttachment, text: messages[0], embed: embed);
 
-        foreach (var message in messages.Skip(1))
-        {
-            await command.FollowupAsync(message);
-        }
+        await SlashCommandResponse.SendFollowupsAsync(command, messages.Skip(1));
     }
 }

--- a/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
+++ b/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
@@ -490,9 +490,9 @@ public sealed class EmbedFactory
         var playerNames = run.Players.Select(player => player.UserName).ToList();
         var blocks = new List<string>();
 
-        blocks.Add(this.CreateTableSection("Current Team", currentTeam, playerNames));
-        blocks.Add(this.CreateTableSection("Box", box, playerNames));
-        blocks.Add(this.CreateTableSection("Dead", run.LinkGroups.Where(group => !group.IsAlive), playerNames));
+        blocks.AddRange(this.CreateTableSections("Current Team", currentTeam, playerNames));
+        blocks.AddRange(this.CreateTableSections("Box", box, playerNames));
+        blocks.AddRange(this.CreateTableSections("Dead", run.LinkGroups.Where(group => !group.IsAlive), playerNames));
 
         return blocks;
     }
@@ -504,15 +504,15 @@ public sealed class EmbedFactory
             this.CreateRunHeader(title, run),
         };
 
-        blocks.Add(this.CreateTeamTableSection(run));
+        blocks.AddRange(this.CreateTeamTableSections(run));
         return blocks;
     }
 
-    private string CreateTeamTableSection(SoulLinkRun run)
+    private IReadOnlyList<string> CreateTeamTableSections(SoulLinkRun run)
     {
         var playerNames = run.Players.Select(player => player.UserName).ToList();
 
-        return this.CreateTableSection("Team", run.ActiveLinks, playerNames);
+        return this.CreateTableSections("Team", run.ActiveLinks, playerNames);
     }
 
     private string CreateRunHeader(string title, SoulLinkRun run)
@@ -523,17 +523,50 @@ public sealed class EmbedFactory
             $"Edition: **{run.Game}**";
     }
 
-    private string CreateTableSection(
+    private IReadOnlyList<string> CreateTableSections(
         string title,
         IEnumerable<LinkGroup?> linkedGroups,
         IReadOnlyList<string> playerNames)
     {
-        var table = this.BuildStringTable(linkedGroups, playerNames);
+        var tableRows = this.BuildStringTableRows(linkedGroups, playerNames);
+        var headerRows = tableRows.Take(2).ToList();
+        var rows = tableRows.Skip(2).ToList();
+
+        if (rows.Count == 0)
+        {
+            return new[] { this.CreateTableSection(title, headerRows) };
+        }
+
+        var sections = new List<string>();
+        var currentRows = new List<string>(headerRows);
+
+        foreach (var row in rows)
+        {
+            var candidateRows = currentRows.Concat(new[] { row }).ToList();
+            var candidateSection = this.CreateTableSection(title, candidateRows);
+            if (currentRows.Count > headerRows.Count && candidateSection.Length > DiscordMessageMaxLength)
+            {
+                sections.Add(this.CreateTableSection(title, currentRows));
+                currentRows = new List<string>(headerRows);
+            }
+
+            currentRows.Add(row);
+        }
+
+        sections.Add(this.CreateTableSection(title, currentRows));
+        return sections;
+    }
+
+    private string CreateTableSection(string title, IReadOnlyList<string> rows)
+    {
+        var table = string.Join(Environment.NewLine, rows);
 
         return $"**{title}**{Environment.NewLine}```{table}```";
     }
 
-    private string BuildStringTable(IEnumerable<LinkGroup?> linkedGroups, IReadOnlyList<string> playerNames)
+    private IReadOnlyList<string> BuildStringTableRows(
+        IEnumerable<LinkGroup?> linkedGroups,
+        IReadOnlyList<string> playerNames)
     {
         const int routeWidth = 14;
         const int playerColumnWidth = 24;
@@ -565,14 +598,20 @@ public sealed class EmbedFactory
             lines.Add(row);
         }
 
-        return string.Join(Environment.NewLine, lines);
+        return lines;
     }
 
     private string PadRight(string value, int totalWidth)
     {
-        return value.Length >= totalWidth
-            ? value + " "
-            : value.PadRight(totalWidth);
+        var singleLineValue = value.ReplaceLineEndings(" ");
+        if (singleLineValue.Length > totalWidth)
+        {
+            singleLineValue = totalWidth <= 3
+                ? singleLineValue[..totalWidth]
+                : string.Concat(singleLineValue.AsSpan(0, totalWidth - 3), "...");
+        }
+
+        return singleLineValue.PadRight(totalWidth);
     }
 
     private string FormatPokemonWithTypes(LinkedPokemon pokemon)

--- a/PokeSoulLinkBot/Bot/Helpers/SlashCommandResponse.cs
+++ b/PokeSoulLinkBot/Bot/Helpers/SlashCommandResponse.cs
@@ -1,5 +1,6 @@
 using Discord;
 using Discord.WebSocket;
+using Serilog;
 
 namespace PokeSoulLinkBot.Bot.Helpers;
 
@@ -50,5 +51,37 @@ public static class SlashCommandResponse
         return command.HasResponded
             ? command.FollowupWithFileAsync(fileAttachment, text: text, embed: embed, ephemeral: ephemeral)
             : command.RespondWithFileAsync(fileAttachment, text: text, embed: embed, ephemeral: ephemeral);
+    }
+
+    /// <summary>
+    /// Sends supplemental slash-command followup messages.
+    /// </summary>
+    /// <param name="command">The slash command interaction.</param>
+    /// <param name="messages">The followup messages.</param>
+    /// <param name="ephemeral">A value indicating whether the responses should be visible only to the caller.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    public static async Task SendFollowupsAsync(
+        SocketSlashCommand command,
+        IEnumerable<string> messages,
+        bool ephemeral = false)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(messages);
+
+        foreach (var message in messages.Where(message => !string.IsNullOrWhiteSpace(message)))
+        {
+            try
+            {
+                await command.FollowupAsync(message, ephemeral: ephemeral);
+            }
+            catch (Exception exception)
+            {
+                Log.Warning(
+                    exception,
+                    "Could not send slash-command followup for /{CommandName}. MessageLength={MessageLength}.",
+                    command.CommandName,
+                    message.Length);
+            }
+        }
     }
 }

--- a/PokeSoulLinkBot/Bot/Program.cs
+++ b/PokeSoulLinkBot/Bot/Program.cs
@@ -56,6 +56,7 @@ internal sealed class Program
         var httpClient = new HttpClient
         {
             BaseAddress = new Uri("https://pokeapi.co/api/v2/"),
+            Timeout = TimeSpan.FromSeconds(5),
         };
 
         var pokemonNameResolver = new PokeApiPokemonNameResolver(httpClient);

--- a/PokeSoulLinkBot/Bot/SlashCommandRouter.cs
+++ b/PokeSoulLinkBot/Bot/SlashCommandRouter.cs
@@ -89,7 +89,7 @@ public sealed class SlashCommandRouter
             var errorMessage = CreateUserFacingErrorMessage(command, exception);
             var errorEmbed = this.embedFactory.CreateErrorEmbed(errorMessage);
 
-            await SlashCommandResponse.SendAsync(command, embed: errorEmbed, ephemeral: true);
+            await TrySendErrorResponseAsync(command, errorEmbed, exception);
         }
     }
 
@@ -149,6 +149,25 @@ public sealed class SlashCommandRouter
     private static long GetElapsedMilliseconds(DateTimeOffset startedAt)
     {
         return (long)(DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
+    }
+
+    private static async Task TrySendErrorResponseAsync(
+        SocketSlashCommand command,
+        Embed errorEmbed,
+        Exception originalException)
+    {
+        try
+        {
+            await SlashCommandResponse.SendAsync(command, embed: errorEmbed, ephemeral: true);
+        }
+        catch (Exception responseException)
+        {
+            Log.Warning(
+                responseException,
+                "Could not send error response for slash command /{CommandName}. OriginalException={OriginalExceptionType}.",
+                command.CommandName,
+                originalException.GetType().Name);
+        }
     }
 
     private static string FormatCommandOptions(SocketSlashCommand command)


### PR DESCRIPTION
Ticket: https://github.com/mpiechot/PokemonSoulLinkDiscord/issues/18
Also addresses: https://github.com/mpiechot/PokemonSoulLinkDiscord/issues/29

## Summary
- Page status/team followups so `/catch`, `/status`, `/team`, `/use`, and `/swap` stay below Discord message limits instead of failing after a state mutation.
- Add guarded supplemental followups and guarded router error responses so Discord response failures are logged without escaping the gateway handler.
- Add bounded HTTP retry handling, a 5s shared HTTP timeout, cached Pokémon name/metadata lookups, and bounded parallel type enrichment for faster status rendering.
- Move remaining external-data console diagnostics to structured Serilog messages.

## Validation
- `dotnet build PokeSoulLinkBot\PokeSoulLinkBot.csproj --no-restore --no-incremental /p:UseAppHost=false /p:UseSharedCompilation=false -o .codex-build-bl011`
- `dotnet test PokeSoulLinkBot.Tests\PokeSoulLinkBot.Tests.csproj --no-restore /p:UseAppHost=false /p:UseSharedCompilation=false -o .codex-test-bl011`
- `git diff --check`
- `git ls-files --eol` for changed text files

Closes #18
Closes #29