### PR TITLE
Add CI checks for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+jobs:
+  build-and-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Restore
+        run: dotnet restore PokeSoulLinkBot.Tests/PokeSoulLinkBot.Tests.csproj --verbosity minimal
+
+      - name: Build bot
+        run: >
+          dotnet build PokeSoulLinkBot/PokeSoulLinkBot.csproj
+          --no-restore
+          --no-incremental
+          --verbosity minimal
+          -p:UseAppHost=false
+          -p:UseSharedCompilation=false
+          -p:OutputPath=../artifacts/build/PokeSoulLinkBot/
+
+      - name: Test
+        run: >
+          dotnet test PokeSoulLinkBot.Tests/PokeSoulLinkBot.Tests.csproj
+          --no-restore
+          --verbosity minimal
+          -p:UseAppHost=false
+          -p:UseSharedCompilation=false
+          -p:OutputPath=../artifacts/test/PokeSoulLinkBot.Tests/


### PR DESCRIPTION
Ticket: https://github.com/mpiechot/PokemonSoulLinkDiscord/issues/38

## Summary
- Add a GitHub Actions workflow for pull requests and pushes to `main`.
- Restore the test project, build the bot with isolated output, and run the xUnit test suite.
- Keep CI build/test outputs in the already ignored `artifacts/` folder.

Closes #38

## Verification
- `dotnet restore PokeSoulLinkBot.Tests\PokeSoulLinkBot.Tests.csproj --verbosity minimal`
- `dotnet build PokeSoulLinkBot\PokeSoulLinkBot.csproj --no-restore --no-incremental --verbosity minimal -p:UseAppHost=false -p:UseSharedCompilation=false -p:OutputPath=..\artifacts\build\PokeSoulLinkBot\`
- `dotnet test PokeSoulLinkBot.Tests\PokeSoulLinkBot.Tests.csproj --no-restore --verbosity minimal -p:UseAppHost=false -p:UseSharedCompilation=false -p:OutputPath=..\artifacts\test\PokeSoulLinkBot.Tests\`