### PR TITLE
Harden run persistence

### DIFF
--- a/PokeSoulLinkBot.Tests/RunStoreTests.cs
+++ b/PokeSoulLinkBot.Tests/RunStoreTests.cs
@@ -1,0 +1,131 @@
+using PokeSoulLinkBot.Core.Models;
+using PokeSoulLinkBot.Infrastructure.Persistence;
+using Xunit;
+
+namespace PokeSoulLinkBot.Tests;
+
+public sealed class RunStoreTests
+{
+    [Fact]
+    public void Constructor_ShouldLoadBackupWhenPrimaryJsonIsCorrupt()
+    {
+        string filePath = CreateTemporaryRunStorePath();
+        try
+        {
+            var store = new RunStore(filePath);
+            store.AddRun(CreateRun("guild-1", "Ruby"));
+            store.Save();
+            File.WriteAllText(filePath, "{ invalid json");
+
+            var reloadedStore = new RunStore(filePath);
+            SoulLinkRun? reloadedRun = reloadedStore.GetActiveRun("guild-1");
+
+            Assert.NotNull(reloadedRun);
+            Assert.Equal("Ruby", reloadedRun.Name);
+
+            reloadedStore.Save();
+            File.WriteAllText(filePath, "{ invalid json again");
+
+            var recoveredStore = new RunStore(filePath);
+            SoulLinkRun? recoveredRun = recoveredStore.GetActiveRun("guild-1");
+
+            Assert.NotNull(recoveredRun);
+            Assert.Equal("Ruby", recoveredRun.Name);
+        }
+        finally
+        {
+            DeleteTemporaryRunStore(filePath);
+        }
+    }
+
+    [Fact]
+    public void Save_ShouldCreateBackupBeforeReplacingExistingPrimary()
+    {
+        string filePath = CreateTemporaryRunStorePath();
+        try
+        {
+            var store = new RunStore(filePath);
+            store.AddRun(CreateRun("guild-1", "Ruby"));
+
+            string firstJson = File.ReadAllText(filePath);
+            store.AddRun(CreateRun("guild-2", "Sapphire"));
+
+            string backupFilePath = filePath + ".bak";
+            Assert.True(File.Exists(backupFilePath));
+            Assert.Equal(firstJson, File.ReadAllText(backupFilePath));
+
+            var reloadedStore = new RunStore(filePath);
+            Assert.NotNull(reloadedStore.GetActiveRun("guild-2"));
+        }
+        finally
+        {
+            DeleteTemporaryRunStore(filePath);
+        }
+    }
+
+    [Fact]
+    public void AddRun_ShouldPersistConcurrentAddsWithoutCorruptingJson()
+    {
+        string filePath = CreateTemporaryRunStorePath();
+        try
+        {
+            var store = new RunStore(filePath);
+
+            Parallel.For(
+                0,
+                24,
+                index => store.AddRun(CreateRun($"guild-{index}", $"Run {index}")));
+
+            var reloadedStore = new RunStore(filePath);
+            for (var index = 0; index < 24; index++)
+            {
+                SoulLinkRun? reloadedRun = reloadedStore.GetActiveRun($"guild-{index}");
+                Assert.NotNull(reloadedRun);
+                Assert.Equal($"Run {index}", reloadedRun.Name);
+            }
+
+            string directoryPath = Path.GetDirectoryName(filePath)!;
+            Assert.Empty(Directory.GetFiles(directoryPath, "*.tmp"));
+        }
+        finally
+        {
+            DeleteTemporaryRunStore(filePath);
+        }
+    }
+
+    private static SoulLinkRun CreateRun(string guildId, string name)
+    {
+        return new SoulLinkRun
+        {
+            Id = Guid.NewGuid(),
+            GuildId = guildId,
+            Name = name,
+            Game = "ruby",
+            StartedAtUtc = DateTime.UtcNow,
+            Players = new List<RunPlayer>
+            {
+                new() { UserId = 1, UserName = "marpie1" },
+                new() { UserId = 2, UserName = "bene" },
+            },
+        };
+    }
+
+    private static string CreateTemporaryRunStorePath()
+    {
+        string directoryPath = Path.Combine(
+            Path.GetTempPath(),
+            "PokeSoulLinkBotTests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directoryPath);
+        return Path.Combine(directoryPath, "runs.json");
+    }
+
+    private static void DeleteTemporaryRunStore(string filePath)
+    {
+        string? directoryPath = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrWhiteSpace(directoryPath) && Directory.Exists(directoryPath))
+        {
+            Directory.Delete(directoryPath, recursive: true);
+        }
+    }
+}

--- a/PokeSoulLinkBot/Application/Services/RunService.cs
+++ b/PokeSoulLinkBot/Application/Services/RunService.cs
@@ -11,6 +11,7 @@ public sealed class RunService : IRunService
     private const string DefaultRouteLossReason = "First encounter was not caught.";
 
     private readonly IRunStore runStore;
+    private readonly object operationLock = new object();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RunService"/> class.
@@ -37,24 +38,27 @@ public sealed class RunService : IRunService
             throw new ArgumentException("At least one player must be provided.", nameof(players));
         }
 
-        if (this.runStore.GetActiveRun(guildId) is not null)
+        lock (this.operationLock)
         {
-            throw new InvalidOperationException("An active run already exists for this guild.");
+            if (this.runStore.GetActiveRun(guildId) is not null)
+            {
+                throw new InvalidOperationException("An active run already exists for this guild.");
+            }
+
+            var run = new SoulLinkRun
+            {
+                Id = Guid.NewGuid(),
+                GuildId = guildId,
+                Name = name,
+                Game = edition,
+                StartedAtUtc = DateTime.UtcNow,
+                Players = players.ToList(),
+            };
+
+            this.runStore.AddRun(run);
+
+            return run;
         }
-
-        var run = new SoulLinkRun
-        {
-            Id = Guid.NewGuid(),
-            GuildId = guildId,
-            Name = name,
-            Game = edition,
-            StartedAtUtc = DateTime.UtcNow,
-            Players = players.ToList(),
-        };
-
-        this.runStore.AddRun(run);
-
-        return run;
     }
 
     /// <inheritdoc />
@@ -62,16 +66,19 @@ public sealed class RunService : IRunService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(guildId);
 
-        SoulLinkRun activeRun = this.GetActiveRun(guildId);
+        lock (this.operationLock)
+        {
+            SoulLinkRun activeRun = this.GetActiveRun(guildId);
 
-        activeRun.EndedAtUtc = DateTime.UtcNow;
-        activeRun.EndReason = string.IsNullOrWhiteSpace(reason)
-            ? "No reason given."
-            : reason;
+            activeRun.EndedAtUtc = DateTime.UtcNow;
+            activeRun.EndReason = string.IsNullOrWhiteSpace(reason)
+                ? "No reason given."
+                : reason;
 
-        this.runStore.Save();
+            this.runStore.Save();
 
-        return activeRun;
+            return activeRun;
+        }
     }
 
     /// <inheritdoc />
@@ -89,39 +96,42 @@ public sealed class RunService : IRunService
         ArgumentException.ThrowIfNullOrWhiteSpace(pokemon);
         ArgumentNullException.ThrowIfNull(pokemonTypes);
 
-        SoulLinkRun activeRun = this.GetActiveRun(guildId);
-
-        RunPlayer? runPlayer = activeRun.Players.FirstOrDefault(player => player.UserId == playerId);
-        if (runPlayer is null)
+        lock (this.operationLock)
         {
-            throw new InvalidOperationException("The specified player is not part of the active run.");
+            SoulLinkRun activeRun = this.GetActiveRun(guildId);
+
+            RunPlayer? runPlayer = activeRun.Players.FirstOrDefault(player => player.UserId == playerId);
+            if (runPlayer is null)
+            {
+                throw new InvalidOperationException("The specified player is not part of the active run.");
+            }
+
+            LinkGroup? existingGroup = activeRun.LinkGroups.FirstOrDefault(group =>
+                string.Equals(group.Route, route, StringComparison.OrdinalIgnoreCase));
+
+            LinkGroup linkGroup = existingGroup ?? this.CreateLinkGroup(activeRun, route);
+
+            bool playerAlreadyRegistered = linkGroup.Entries.Any(entry => entry.PlayerUserId == playerId);
+            if (playerAlreadyRegistered)
+            {
+                throw new InvalidOperationException("The player already has a registered catch for this route.");
+            }
+
+            linkGroup.Entries.Add(new LinkedPokemon
+            {
+                PlayerUserId = playerId,
+                PlayerName = playerName,
+                PokemonName = pokemon,
+                Types = pokemonTypes.ToList(),
+                IsAlive = true,
+                CaughtAtUtc = DateTime.UtcNow,
+            });
+
+            activeRun.TryAddToActive(linkGroup);
+            this.runStore.Save();
+
+            return linkGroup;
         }
-
-        LinkGroup? existingGroup = activeRun.LinkGroups.FirstOrDefault(group =>
-            string.Equals(group.Route, route, StringComparison.OrdinalIgnoreCase));
-
-        LinkGroup linkGroup = existingGroup ?? this.CreateLinkGroup(activeRun, route);
-
-        bool playerAlreadyRegistered = linkGroup.Entries.Any(entry => entry.PlayerUserId == playerId);
-        if (playerAlreadyRegistered)
-        {
-            throw new InvalidOperationException("The player already has a registered catch for this route.");
-        }
-
-        linkGroup.Entries.Add(new LinkedPokemon
-        {
-            PlayerUserId = playerId,
-            PlayerName = playerName,
-            PokemonName = pokemon,
-            Types = pokemonTypes.ToList(),
-            IsAlive = true,
-            CaughtAtUtc = DateTime.UtcNow,
-        });
-
-        activeRun.TryAddToActive(linkGroup);
-        this.runStore.Save();
-
-        return linkGroup;
     }
 
     /// <inheritdoc />
@@ -135,42 +145,45 @@ public sealed class RunService : IRunService
         ArgumentException.ThrowIfNullOrWhiteSpace(guildId);
         ArgumentException.ThrowIfNullOrWhiteSpace(route);
 
-        SoulLinkRun activeRun = this.GetActiveRun(guildId);
-        var normalizedRoute = this.NormalizeRoute(route);
-
-        if (playerId.HasValue && activeRun.Players.All(player => player.UserId != playerId.Value))
+        lock (this.operationLock)
         {
-            throw new InvalidOperationException("The specified player is not part of the active run.");
+            SoulLinkRun activeRun = this.GetActiveRun(guildId);
+            var normalizedRoute = this.NormalizeRoute(route);
+
+            if (playerId.HasValue && activeRun.Players.All(player => player.UserId != playerId.Value))
+            {
+                throw new InvalidOperationException("The specified player is not part of the active run.");
+            }
+
+            LinkGroup? existingGroup = activeRun.LinkGroups.FirstOrDefault(group =>
+                string.Equals(group.Route, normalizedRoute, StringComparison.OrdinalIgnoreCase));
+
+            if (existingGroup?.Entries.Count > 0)
+            {
+                throw new InvalidOperationException("The route already has registered catches and must be marked dead with /death.");
+            }
+
+            if (existingGroup?.IsLostWithoutEncounter == true)
+            {
+                throw new InvalidOperationException("The route has already been marked as lost.");
+            }
+
+            LinkGroup linkGroup = existingGroup ?? this.CreateLinkGroup(activeRun, normalizedRoute);
+            linkGroup.IsLostWithoutEncounter = true;
+            linkGroup.LossReason = string.IsNullOrWhiteSpace(reason)
+                ? DefaultRouteLossReason
+                : reason.Trim();
+            linkGroup.FailedEncounterPlayerUserId = playerId;
+            linkGroup.FailedEncounterPlayerName = string.IsNullOrWhiteSpace(playerName)
+                ? null
+                : playerName.Trim();
+            linkGroup.LostAtUtc = DateTime.UtcNow;
+
+            this.RemoveFromActiveLinks(activeRun, linkGroup);
+            this.runStore.Save();
+
+            return linkGroup;
         }
-
-        LinkGroup? existingGroup = activeRun.LinkGroups.FirstOrDefault(group =>
-            string.Equals(group.Route, normalizedRoute, StringComparison.OrdinalIgnoreCase));
-
-        if (existingGroup?.Entries.Count > 0)
-        {
-            throw new InvalidOperationException("The route already has registered catches and must be marked dead with /death.");
-        }
-
-        if (existingGroup?.IsLostWithoutEncounter == true)
-        {
-            throw new InvalidOperationException("The route has already been marked as lost.");
-        }
-
-        LinkGroup linkGroup = existingGroup ?? this.CreateLinkGroup(activeRun, normalizedRoute);
-        linkGroup.IsLostWithoutEncounter = true;
-        linkGroup.LossReason = string.IsNullOrWhiteSpace(reason)
-            ? DefaultRouteLossReason
-            : reason.Trim();
-        linkGroup.FailedEncounterPlayerUserId = playerId;
-        linkGroup.FailedEncounterPlayerName = string.IsNullOrWhiteSpace(playerName)
-            ? null
-            : playerName.Trim();
-        linkGroup.LostAtUtc = DateTime.UtcNow;
-
-        this.RemoveFromActiveLinks(activeRun, linkGroup);
-        this.runStore.Save();
-
-        return linkGroup;
     }
 
     /// <inheritdoc />
@@ -184,13 +197,16 @@ public sealed class RunService : IRunService
             throw new ArgumentOutOfRangeException(nameof(position), "Position must be between 1 and 6.");
         }
 
-        SoulLinkRun activeRun = this.GetActiveRun(guildId);
-        LinkGroup linkGroup = this.GetAliveLinkGroup(activeRun, route);
+        lock (this.operationLock)
+        {
+            SoulLinkRun activeRun = this.GetActiveRun(guildId);
+            LinkGroup linkGroup = this.GetAliveLinkGroup(activeRun, route);
 
-        activeRun.ActiveLinks[position - 1] = linkGroup;
-        this.runStore.Save();
+            activeRun.ActiveLinks[position - 1] = linkGroup;
+            this.runStore.Save();
 
-        return activeRun;
+            return activeRun;
+        }
     }
 
     /// <inheritdoc />
@@ -200,31 +216,34 @@ public sealed class RunService : IRunService
         ArgumentException.ThrowIfNullOrWhiteSpace(teamRoute);
         ArgumentException.ThrowIfNullOrWhiteSpace(boxRoute);
 
-        SoulLinkRun activeRun = this.GetActiveRun(guildId);
-        var normalizedTeamRoute = this.NormalizeRoute(teamRoute);
-        LinkGroup boxLinkGroup = this.GetAliveLinkGroup(activeRun, boxRoute);
-
-        var activeIndex = Array.FindIndex(
-            activeRun.ActiveLinks,
-            activeLink => activeLink != null &&
-                string.Equals(activeLink.Route, normalizedTeamRoute, StringComparison.OrdinalIgnoreCase));
-
-        if (activeIndex < 0)
+        lock (this.operationLock)
         {
-            throw new InvalidOperationException($"Route '{normalizedTeamRoute}' is not in the current team.");
+            SoulLinkRun activeRun = this.GetActiveRun(guildId);
+            var normalizedTeamRoute = this.NormalizeRoute(teamRoute);
+            LinkGroup boxLinkGroup = this.GetAliveLinkGroup(activeRun, boxRoute);
+
+            var activeIndex = Array.FindIndex(
+                activeRun.ActiveLinks,
+                activeLink => activeLink != null &&
+                    string.Equals(activeLink.Route, normalizedTeamRoute, StringComparison.OrdinalIgnoreCase));
+
+            if (activeIndex < 0)
+            {
+                throw new InvalidOperationException($"Route '{normalizedTeamRoute}' is not in the current team.");
+            }
+
+            if (activeRun.ActiveLinks.Any(activeLink =>
+                activeLink != null &&
+                string.Equals(activeLink.Route, boxLinkGroup.Route, StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new InvalidOperationException($"Route '{boxLinkGroup.Route}' is already in the current team.");
+            }
+
+            activeRun.ActiveLinks[activeIndex] = boxLinkGroup;
+            this.runStore.Save();
+
+            return activeRun;
         }
-
-        if (activeRun.ActiveLinks.Any(activeLink =>
-            activeLink != null &&
-            string.Equals(activeLink.Route, boxLinkGroup.Route, StringComparison.OrdinalIgnoreCase)))
-        {
-            throw new InvalidOperationException($"Route '{boxLinkGroup.Route}' is already in the current team.");
-        }
-
-        activeRun.ActiveLinks[activeIndex] = boxLinkGroup;
-        this.runStore.Save();
-
-        return activeRun;
     }
 
     /// <inheritdoc />
@@ -239,35 +258,38 @@ public sealed class RunService : IRunService
         ArgumentException.ThrowIfNullOrWhiteSpace(route);
         ArgumentException.ThrowIfNullOrWhiteSpace(reason);
 
-        SoulLinkRun activeRun = this.GetActiveRun(guildId);
-
-        if (playerId.HasValue && activeRun.Players.All(player => player.UserId != playerId.Value))
+        lock (this.operationLock)
         {
-            throw new InvalidOperationException("The specified player is not part of the active run.");
+            SoulLinkRun activeRun = this.GetActiveRun(guildId);
+
+            if (playerId.HasValue && activeRun.Players.All(player => player.UserId != playerId.Value))
+            {
+                throw new InvalidOperationException("The specified player is not part of the active run.");
+            }
+
+            LinkGroup? linkGroup = activeRun.LinkGroups.FirstOrDefault(group =>
+                group.Route.Equals(route, StringComparison.OrdinalIgnoreCase));
+
+            if (linkGroup is null)
+            {
+                throw new InvalidOperationException("The specified Pokémon was not found in the active run.");
+            }
+
+            foreach (LinkedPokemon entry in linkGroup.Entries)
+            {
+                entry.IsAlive = false;
+                entry.DiedAtUtc = DateTime.UtcNow;
+                entry.DeathReason = reason.Trim();
+                entry.DeathCausedByPlayerUserId = playerId;
+                entry.DeathCausedByPlayerName = string.IsNullOrWhiteSpace(playerName)
+                    ? null
+                    : playerName.Trim();
+            }
+
+            this.runStore.Save();
+
+            return linkGroup;
         }
-
-        LinkGroup? linkGroup = activeRun.LinkGroups.FirstOrDefault(group =>
-            group.Route.Equals(route, StringComparison.OrdinalIgnoreCase));
-
-        if (linkGroup is null)
-        {
-            throw new InvalidOperationException("The specified Pokémon was not found in the active run.");
-        }
-
-        foreach (LinkedPokemon entry in linkGroup.Entries)
-        {
-            entry.IsAlive = false;
-            entry.DiedAtUtc = DateTime.UtcNow;
-            entry.DeathReason = reason.Trim();
-            entry.DeathCausedByPlayerUserId = playerId;
-            entry.DeathCausedByPlayerName = string.IsNullOrWhiteSpace(playerName)
-                ? null
-                : playerName.Trim();
-        }
-
-        this.runStore.Save();
-
-        return linkGroup;
     }
 
     /// <inheritdoc />
@@ -275,8 +297,11 @@ public sealed class RunService : IRunService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(guildId);
 
-        return this.runStore.GetActiveRun(guildId)
-            ?? throw new InvalidOperationException("There is no active run for this guild.");
+        lock (this.operationLock)
+        {
+            return this.runStore.GetActiveRun(guildId)
+                ?? throw new InvalidOperationException("There is no active run for this guild.");
+        }
     }
 
     /// <inheritdoc />
@@ -284,7 +309,10 @@ public sealed class RunService : IRunService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(guildId);
 
-        return this.runStore.GetRunsForGuild(guildId);
+        lock (this.operationLock)
+        {
+            return this.runStore.GetRunsForGuild(guildId);
+        }
     }
 
     private LinkGroup CreateLinkGroup(SoulLinkRun run, string route)

--- a/PokeSoulLinkBot/Persistence/RunStore.cs
+++ b/PokeSoulLinkBot/Persistence/RunStore.cs
@@ -9,9 +9,17 @@ namespace PokeSoulLinkBot.Infrastructure.Persistence;
 /// </summary>
 public sealed class RunStore : IRunStore
 {
+    private const string BackupFileSuffix = ".bak";
+
     private readonly string filePath;
+    private readonly string backupFilePath;
     private readonly JsonSerializerOptions jsonSerializerOptions;
+    private readonly object stateLock = new object();
+    private readonly object fileLock = new object();
     private readonly List<SoulLinkRun> runs;
+    private long nextSaveVersion;
+    private long persistedSaveVersion;
+    private bool canBackupPrimaryFile;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RunStore"/> class.
@@ -20,6 +28,7 @@ public sealed class RunStore : IRunStore
     public RunStore(string filePath)
     {
         this.filePath = filePath;
+        this.backupFilePath = filePath + BackupFileSuffix;
         this.jsonSerializerOptions = new JsonSerializerOptions
         {
             WriteIndented = true,
@@ -31,27 +40,86 @@ public sealed class RunStore : IRunStore
     /// <inheritdoc />
     public SoulLinkRun? GetActiveRun(string guildId)
     {
-        return this.runs.LastOrDefault(run => run.GuildId == guildId && run.EndedAtUtc is null);
+        lock (this.stateLock)
+        {
+            return this.runs.LastOrDefault(run => run.GuildId == guildId && run.EndedAtUtc is null);
+        }
     }
 
     /// <inheritdoc />
     public IReadOnlyList<SoulLinkRun> GetRunsForGuild(string guildId)
     {
-        return this.runs
-            .Where(run => run.GuildId == guildId)
-            .OrderByDescending(run => run.StartedAtUtc)
-            .ToList();
+        lock (this.stateLock)
+        {
+            return this.runs
+                .Where(run => run.GuildId == guildId)
+                .OrderByDescending(run => run.StartedAtUtc)
+                .ToList();
+        }
     }
 
     /// <inheritdoc />
     public void AddRun(SoulLinkRun run)
     {
-        this.runs.Add(run);
-        this.Save();
+        ArgumentNullException.ThrowIfNull(run);
+
+        RunStoreSnapshot snapshot;
+        lock (this.stateLock)
+        {
+            this.runs.Add(run);
+            snapshot = this.CreateSnapshotCore();
+        }
+
+        this.SaveSnapshot(snapshot);
     }
 
     /// <inheritdoc />
     public void Save()
+    {
+        RunStoreSnapshot snapshot = this.CreateSnapshot();
+        this.SaveSnapshot(snapshot);
+    }
+
+    private RunStoreSnapshot CreateSnapshot()
+    {
+        lock (this.stateLock)
+        {
+            return this.CreateSnapshotCore();
+        }
+    }
+
+    private RunStoreSnapshot CreateSnapshotCore()
+    {
+        string json = JsonSerializer.Serialize(this.runs, this.jsonSerializerOptions);
+        return new RunStoreSnapshot(++this.nextSaveVersion, json);
+    }
+
+    private void SaveSnapshot(RunStoreSnapshot snapshot)
+    {
+        lock (this.fileLock)
+        {
+            if (snapshot.Version < this.persistedSaveVersion)
+            {
+                return;
+            }
+
+            string directoryPath = this.EnsureDirectory();
+            string tempFilePath = this.CreateTempFilePath(directoryPath);
+
+            try
+            {
+                this.WriteAllText(tempFilePath, snapshot.Json);
+                this.ReplacePersistedFile(tempFilePath);
+                this.persistedSaveVersion = snapshot.Version;
+            }
+            finally
+            {
+                this.DeleteFileIfExists(tempFilePath);
+            }
+        }
+    }
+
+    private string EnsureDirectory()
     {
         string directoryPath = Path.GetDirectoryName(this.filePath) ?? string.Empty;
 
@@ -60,24 +128,117 @@ public sealed class RunStore : IRunStore
             Directory.CreateDirectory(directoryPath);
         }
 
-        string json = JsonSerializer.Serialize(this.runs, this.jsonSerializerOptions);
-        File.WriteAllText(this.filePath, json);
+        return directoryPath;
+    }
+
+    private string CreateTempFilePath(string directoryPath)
+    {
+        string tempFileName = $"{Path.GetFileName(this.filePath)}.{Guid.NewGuid():N}.tmp";
+
+        return string.IsNullOrWhiteSpace(directoryPath)
+            ? tempFileName
+            : Path.Combine(directoryPath, tempFileName);
+    }
+
+    private void ReplacePersistedFile(string tempFilePath)
+    {
+        if (File.Exists(this.filePath))
+        {
+            if (this.canBackupPrimaryFile)
+            {
+                File.Copy(this.filePath, this.backupFilePath, overwrite: true);
+            }
+
+            File.Move(tempFilePath, this.filePath, overwrite: true);
+            this.canBackupPrimaryFile = true;
+            return;
+        }
+
+        File.Move(tempFilePath, this.filePath);
+        this.canBackupPrimaryFile = true;
     }
 
     private List<SoulLinkRun> LoadRuns()
     {
-        if (!File.Exists(this.filePath))
+        if (this.TryLoadRuns(this.filePath, out List<SoulLinkRun> persistedRuns))
         {
-            return new List<SoulLinkRun>();
+            this.canBackupPrimaryFile = true;
+            return persistedRuns;
         }
 
-        string json = File.ReadAllText(this.filePath);
-
-        if (string.IsNullOrWhiteSpace(json))
+        if (this.TryLoadRuns(this.backupFilePath, out List<SoulLinkRun> backupRuns))
         {
-            return new List<SoulLinkRun>();
+            this.canBackupPrimaryFile = false;
+            return backupRuns;
         }
 
-        return JsonSerializer.Deserialize<List<SoulLinkRun>>(json) ?? new List<SoulLinkRun>();
+        this.canBackupPrimaryFile = false;
+        return new List<SoulLinkRun>();
+    }
+
+    private bool TryLoadRuns(string path, out List<SoulLinkRun> persistedRuns)
+    {
+        persistedRuns = new List<SoulLinkRun>();
+
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        try
+        {
+            string json = File.ReadAllText(path);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return false;
+            }
+
+            persistedRuns = JsonSerializer.Deserialize<List<SoulLinkRun>>(json) ?? new List<SoulLinkRun>();
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
+
+    private void WriteAllText(string path, string content)
+    {
+        using var stream = new FileStream(
+            path,
+            FileMode.CreateNew,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 4096,
+            FileOptions.WriteThrough);
+        using var writer = new StreamWriter(stream);
+        writer.Write(content);
+        writer.Flush();
+        stream.Flush(flushToDisk: true);
+    }
+
+    private void DeleteFileIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+
+    private readonly struct RunStoreSnapshot
+    {
+        public RunStoreSnapshot(long version, string json)
+        {
+            this.Version = version;
+            this.Json = json;
+        }
+
+        public long Version { get; }
+
+        public string Json { get; }
     }
 }


### PR DESCRIPTION
Ticket: https://github.com/mpiechot/PokemonSoulLinkDiscord/issues/39

## Summary
- Serialize run mutations through `RunService` so concurrent commands cannot update the same run graph at the same time.
- Persist run data through versioned snapshots, temp files, atomic replacement, and a last-known-good `.bak` file.
- Load the backup file when the primary JSON is empty or corrupt, without overwriting a valid backup during recovery.
- Add focused `RunStore` tests for corrupt primary recovery, backup creation, and concurrent writes.

Closes #39

## Verification
- `dotnet build PokeSoulLinkBot\PokeSoulLinkBot.csproj --no-restore --verbosity minimal`
- `dotnet test PokeSoulLinkBot.Tests\PokeSoulLinkBot.Tests.csproj --no-restore --verbosity minimal`