### PR TITLE
Persist Pokemon data cache

### DIFF
--- a/PokeSoulLinkBot.Tests/PokeApiPokedexServiceTests.cs
+++ b/PokeSoulLinkBot.Tests/PokeApiPokedexServiceTests.cs
@@ -1,0 +1,101 @@
+using PokeSoulLinkBot.Application.Interfaces;
+using PokeSoulLinkBot.Application.Services;
+using PokeSoulLinkBot.Core.Models;
+using Xunit;
+
+namespace PokeSoulLinkBot.Tests;
+
+public sealed class PokeApiPokedexServiceTests
+{
+    [Fact]
+    public async Task GetPokedexEntryAsync_ShouldUsePersistedCacheWhenAvailable()
+    {
+        string cacheFilePath = CreateTemporaryCacheFilePath();
+        try
+        {
+            var cacheStore = new PokemonDataCacheStore(cacheFilePath);
+            await cacheStore.SavePokedexEntryAsync("bulbasaur", new PokedexEntry
+            {
+                PokemonName = "Bulbasaur",
+                ImageUrl = "https://img.example/bulbasaur.png",
+                Rows = new List<PokedexTableRow>
+                {
+                    new()
+                    {
+                        PokemonName = "Bulbasaur",
+                        RequirementText = "Basis",
+                        Types = new[] { "Grass", "Poison" },
+                    },
+                },
+            });
+
+            var handler = new CountingPokedexHttpMessageHandler();
+            using var httpClient = new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://pokeapi.co/api/v2/"),
+            };
+            var service = new PokeApiPokedexService(
+                httpClient,
+                new StubPokemonNameResolver("bulbasaur"),
+                cacheStore);
+
+            PokedexEntry entry = await service.GetPokedexEntryAsync("Bisasam");
+
+            Assert.Equal("Bulbasaur", entry.PokemonName);
+            Assert.Equal("https://img.example/bulbasaur.png", entry.ImageUrl);
+            Assert.Single(entry.Rows);
+            Assert.Equal(0, handler.RequestCount);
+        }
+        finally
+        {
+            DeleteTemporaryCacheFile(cacheFilePath);
+        }
+    }
+
+    private static string CreateTemporaryCacheFilePath()
+    {
+        string directoryPath = Path.Combine(
+            Path.GetTempPath(),
+            "PokeSoulLinkBotTests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directoryPath);
+        return Path.Combine(directoryPath, "pokemon-data-cache.json");
+    }
+
+    private static void DeleteTemporaryCacheFile(string cacheFilePath)
+    {
+        string? directoryPath = Path.GetDirectoryName(cacheFilePath);
+        if (!string.IsNullOrWhiteSpace(directoryPath) && Directory.Exists(directoryPath))
+        {
+            Directory.Delete(directoryPath, recursive: true);
+        }
+    }
+
+    private sealed class StubPokemonNameResolver : IPokemonNameResolver
+    {
+        private readonly string resolvedName;
+
+        public StubPokemonNameResolver(string resolvedName)
+        {
+            this.resolvedName = resolvedName;
+        }
+
+        public Task<string> ResolvePokemonNameAsync(string pokemonName)
+        {
+            return Task.FromResult(this.resolvedName);
+        }
+    }
+
+    private sealed class CountingPokedexHttpMessageHandler : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            this.RequestCount++;
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.InternalServerError));
+        }
+    }
+}

--- a/PokeSoulLinkBot.Tests/PokeApiPokemonLookupServiceTests.cs
+++ b/PokeSoulLinkBot.Tests/PokeApiPokemonLookupServiceTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using PokeSoulLinkBot.Application.Interfaces;
 using PokeSoulLinkBot.Application.Services;
+using PokeSoulLinkBot.Core.Models;
 using Xunit;
 
 namespace PokeSoulLinkBot.Tests;
@@ -40,6 +41,107 @@ public sealed class PokeApiPokemonLookupServiceTests
 
         Assert.NotNull(pokemonInfo);
         Assert.Equal(2, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task GetPokemonInfoAsync_ShouldUsePersistedCacheWhenAvailable()
+    {
+        string cacheFilePath = CreateTemporaryCacheFilePath();
+        try
+        {
+            var cacheStore = new PokemonDataCacheStore(cacheFilePath);
+            await cacheStore.SavePokemonInfoAsync("bulbasaur", new PokemonInfo
+            {
+                ImageUrl = "https://img.example/cached-bulbasaur.png",
+                Types = new[] { "grass", "poison" },
+            });
+
+            var handler = new CountingPokemonHttpMessageHandler();
+            using var httpClient = new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://pokeapi.co/api/v2/"),
+            };
+            var service = new PokeApiPokemonLookupService(
+                httpClient,
+                new StubPokemonNameResolver("bulbasaur"),
+                cacheStore);
+
+            PokemonInfo? pokemonInfo = await service.GetPokemonInfoAsync("Bisasam");
+
+            Assert.NotNull(pokemonInfo);
+            Assert.Equal("https://img.example/cached-bulbasaur.png", pokemonInfo.ImageUrl);
+            Assert.Equal(new[] { "grass", "poison" }, pokemonInfo.Types);
+            Assert.Equal(0, handler.RequestCount);
+        }
+        finally
+        {
+            DeleteTemporaryCacheFile(cacheFilePath);
+        }
+    }
+
+    [Fact]
+    public async Task GetPokemonInfoAsync_ShouldPersistSuccessfulLookupsForLaterRequests()
+    {
+        string cacheFilePath = CreateTemporaryCacheFilePath();
+        try
+        {
+            var cacheStore = new PokemonDataCacheStore(cacheFilePath);
+            var handler = new CountingPokemonHttpMessageHandler();
+            using var httpClient = new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://pokeapi.co/api/v2/"),
+            };
+            var service = new PokeApiPokemonLookupService(
+                httpClient,
+                new StubPokemonNameResolver("bulbasaur"),
+                cacheStore);
+
+            PokemonInfo? fetchedInfo = await service.GetPokemonInfoAsync("Bulbasaur");
+
+            Assert.NotNull(fetchedInfo);
+            Assert.Equal(1, handler.RequestCount);
+
+            var reloadedCacheStore = new PokemonDataCacheStore(cacheFilePath);
+            var offlineHandler = new CountingPokemonHttpMessageHandler();
+            using var offlineHttpClient = new HttpClient(offlineHandler)
+            {
+                BaseAddress = new Uri("https://pokeapi.co/api/v2/"),
+            };
+            var offlineService = new PokeApiPokemonLookupService(
+                offlineHttpClient,
+                new StubPokemonNameResolver("bulbasaur"),
+                reloadedCacheStore);
+
+            PokemonInfo? cachedInfo = await offlineService.GetPokemonInfoAsync("Bulbasaur");
+
+            Assert.NotNull(cachedInfo);
+            Assert.Equal(fetchedInfo.ImageUrl, cachedInfo.ImageUrl);
+            Assert.Equal(fetchedInfo.Types, cachedInfo.Types);
+            Assert.Equal(0, offlineHandler.RequestCount);
+        }
+        finally
+        {
+            DeleteTemporaryCacheFile(cacheFilePath);
+        }
+    }
+
+    private static string CreateTemporaryCacheFilePath()
+    {
+        string directoryPath = Path.Combine(
+            Path.GetTempPath(),
+            "PokeSoulLinkBotTests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directoryPath);
+        return Path.Combine(directoryPath, "pokemon-data-cache.json");
+    }
+
+    private static void DeleteTemporaryCacheFile(string cacheFilePath)
+    {
+        string? directoryPath = Path.GetDirectoryName(cacheFilePath);
+        if (!string.IsNullOrWhiteSpace(directoryPath) && Directory.Exists(directoryPath))
+        {
+            Directory.Delete(directoryPath, recursive: true);
+        }
     }
 
     private static HttpResponseMessage CreatePokemonResponse()

--- a/PokeSoulLinkBot.Tests/PokeApiPokemonNameResolverTests.cs
+++ b/PokeSoulLinkBot.Tests/PokeApiPokemonNameResolverTests.cs
@@ -25,6 +25,56 @@ public sealed class PokeApiPokemonNameResolverTests
         Assert.Equal(1, handler.RequestCount);
     }
 
+    [Fact]
+    public async Task ResolvePokemonNameAsync_ShouldUsePersistedLocalizedNameIndex()
+    {
+        string cacheFilePath = CreateTemporaryCacheFilePath();
+        try
+        {
+            var cacheStore = new PokemonDataCacheStore(cacheFilePath);
+            await cacheStore.SaveNameIndexAsync(new Dictionary<string, string>
+            {
+                ["bisasam"] = "bulbasaur",
+            });
+
+            var handler = new NotFoundNameResolverHttpMessageHandler();
+            using var httpClient = new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://pokeapi.co/api/v2/"),
+            };
+            var resolver = new PokeApiPokemonNameResolver(httpClient, cacheStore);
+
+            var resolvedName = await resolver.ResolvePokemonNameAsync("Bisasam");
+
+            Assert.Equal("bulbasaur", resolvedName);
+            Assert.Equal(1, handler.DirectRequestCount);
+            Assert.Equal(0, handler.SpeciesIndexRequestCount);
+        }
+        finally
+        {
+            DeleteTemporaryCacheFile(cacheFilePath);
+        }
+    }
+
+    private static string CreateTemporaryCacheFilePath()
+    {
+        string directoryPath = Path.Combine(
+            Path.GetTempPath(),
+            "PokeSoulLinkBotTests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directoryPath);
+        return Path.Combine(directoryPath, "pokemon-data-cache.json");
+    }
+
+    private static void DeleteTemporaryCacheFile(string cacheFilePath)
+    {
+        string? directoryPath = Path.GetDirectoryName(cacheFilePath);
+        if (!string.IsNullOrWhiteSpace(directoryPath) && Directory.Exists(directoryPath))
+        {
+            Directory.Delete(directoryPath, recursive: true);
+        }
+    }
+
     private sealed class CountingNameResolverHttpMessageHandler : HttpMessageHandler
     {
         public int RequestCount { get; private set; }
@@ -46,6 +96,29 @@ public sealed class PokeApiPokemonNameResolverTests
                     Encoding.UTF8,
                     "application/json"),
             });
+        }
+    }
+
+    private sealed class NotFoundNameResolverHttpMessageHandler : HttpMessageHandler
+    {
+        public int DirectRequestCount { get; private set; }
+
+        public int SpeciesIndexRequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request.RequestUri?.AbsolutePath.Contains("pokemon-species", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                this.SpeciesIndexRequestCount++;
+            }
+            else
+            {
+                this.DirectRequestCount++;
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
         }
     }
 }

--- a/PokeSoulLinkBot/Application/Services/PokeApiPokedexService.cs
+++ b/PokeSoulLinkBot/Application/Services/PokeApiPokedexService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using PokeSoulLinkBot.Application.Interfaces;
 using PokeSoulLinkBot.Core.Dtos;
@@ -16,21 +17,27 @@ public sealed class PokeApiPokedexService : IPokedexService
 
     private readonly HttpClient httpClient;
     private readonly IPokemonNameResolver pokemonNameResolver;
+    private readonly PokemonDataCacheStore? pokemonDataCacheStore;
+    private readonly ConcurrentDictionary<string, PokedexEntry> pokedexEntryCache =
+        new ConcurrentDictionary<string, PokedexEntry>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PokeApiPokedexService"/> class.
     /// </summary>
     /// <param name="httpClient">The HTTP client.</param>
     /// <param name="pokemonNameResolver">The Pokémon name resolver.</param>
+    /// <param name="pokemonDataCacheStore">The optional persistent Pokémon data cache.</param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when one of the parameters is <see langword="null"/>.
     /// </exception>
     public PokeApiPokedexService(
         HttpClient httpClient,
-        IPokemonNameResolver pokemonNameResolver)
+        IPokemonNameResolver pokemonNameResolver,
+        PokemonDataCacheStore? pokemonDataCacheStore = null)
     {
         this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         this.pokemonNameResolver = pokemonNameResolver ?? throw new ArgumentNullException(nameof(pokemonNameResolver));
+        this.pokemonDataCacheStore = pokemonDataCacheStore;
     }
 
     /// <inheritdoc />
@@ -39,6 +46,29 @@ public sealed class PokeApiPokedexService : IPokedexService
         ArgumentException.ThrowIfNullOrWhiteSpace(pokemonName);
 
         var normalizedPokemonName = await this.pokemonNameResolver.ResolvePokemonNameAsync(pokemonName);
+        var cacheKey = NormalizePokemonName(normalizedPokemonName);
+
+        if (this.pokedexEntryCache.TryGetValue(cacheKey, out PokedexEntry? cachedEntry))
+        {
+            Log.Debug(
+                "Using cached Pokedex entry for '{PokemonName}' resolved as '{ResolvedPokemonName}'.",
+                pokemonName,
+                normalizedPokemonName);
+            return cachedEntry;
+        }
+
+        PokedexEntry? persistedEntry = this.pokemonDataCacheStore is null
+            ? null
+            : await this.pokemonDataCacheStore.GetPokedexEntryAsync(cacheKey);
+        if (persistedEntry is not null)
+        {
+            Log.Debug(
+                "Using persisted Pokedex entry for '{PokemonName}' resolved as '{ResolvedPokemonName}'.",
+                pokemonName,
+                normalizedPokemonName);
+            this.pokedexEntryCache.TryAdd(cacheKey, persistedEntry);
+            return persistedEntry;
+        }
 
         var requestedPokemon = await this.GetPokemonAsync(normalizedPokemonName)
             ?? throw CreatePokemonNotFoundException(pokemonName, normalizedPokemonName);
@@ -71,12 +101,20 @@ public sealed class PokeApiPokedexService : IPokedexService
                 normalizedPokemonName);
         }
 
-        return new PokedexEntry
+        var pokedexEntry = new PokedexEntry
         {
             PokemonName = FormatResourceName(requestedPokemon.Name ?? normalizedPokemonName),
             ImageUrl = imageUrl,
             Rows = rows,
         };
+
+        this.pokedexEntryCache.TryAdd(cacheKey, pokedexEntry);
+        if (this.pokemonDataCacheStore is not null)
+        {
+            await this.pokemonDataCacheStore.SavePokedexEntryAsync(cacheKey, pokedexEntry);
+        }
+
+        return pokedexEntry;
     }
 
     private static IReadOnlyList<string> GetFormattedTypes(PokemonDto pokemon)

--- a/PokeSoulLinkBot/Application/Services/PokeApiPokemonLookupService.cs
+++ b/PokeSoulLinkBot/Application/Services/PokeApiPokemonLookupService.cs
@@ -17,6 +17,7 @@ public sealed class PokeApiPokemonLookupService : IPokemonLookupService
 
     private readonly HttpClient httpClient;
     private readonly IPokemonNameResolver pokemonNameResolver;
+    private readonly PokemonDataCacheStore? pokemonDataCacheStore;
     private readonly ConcurrentDictionary<string, PokemonInfo> pokemonInfoCache =
         new ConcurrentDictionary<string, PokemonInfo>(StringComparer.OrdinalIgnoreCase);
 
@@ -25,15 +26,18 @@ public sealed class PokeApiPokemonLookupService : IPokemonLookupService
     /// </summary>
     /// <param name="httpClient">The HTTP client.</param>
     /// <param name="pokemonNameResolver">The Pokémon name resolver.</param>
+    /// <param name="pokemonDataCacheStore">The optional persistent Pokémon data cache.</param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when one of the parameters is <see langword="null"/>.
     /// </exception>
     public PokeApiPokemonLookupService(
         HttpClient httpClient,
-        IPokemonNameResolver pokemonNameResolver)
+        IPokemonNameResolver pokemonNameResolver,
+        PokemonDataCacheStore? pokemonDataCacheStore = null)
     {
         this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         this.pokemonNameResolver = pokemonNameResolver ?? throw new ArgumentNullException(nameof(pokemonNameResolver));
+        this.pokemonDataCacheStore = pokemonDataCacheStore;
     }
 
     /// <inheritdoc />
@@ -57,6 +61,19 @@ public sealed class PokeApiPokemonLookupService : IPokemonLookupService
         {
             Log.Debug("Using cached Pokemon info for '{PokemonName}' resolved as '{ResolvedName}'.", pokemonName, resolvedName);
             return cachedInfo;
+        }
+
+        PokemonInfo? persistedInfo = this.pokemonDataCacheStore is null
+            ? null
+            : await this.pokemonDataCacheStore.GetPokemonInfoAsync(resolvedName);
+        if (persistedInfo is not null)
+        {
+            Log.Debug(
+                "Using persisted Pokemon info for '{PokemonName}' resolved as '{ResolvedName}'.",
+                pokemonName,
+                resolvedName);
+            this.pokemonInfoCache.TryAdd(resolvedName, persistedInfo);
+            return persistedInfo;
         }
 
         var requestUri = $"pokemon/{Uri.EscapeDataString(resolvedName)}";
@@ -121,6 +138,11 @@ public sealed class PokeApiPokemonLookupService : IPokemonLookupService
         };
 
         this.pokemonInfoCache.TryAdd(resolvedName, pokemonInfo);
+        if (this.pokemonDataCacheStore is not null)
+        {
+            await this.pokemonDataCacheStore.SavePokemonInfoAsync(resolvedName, pokemonInfo);
+        }
+
         return pokemonInfo;
     }
 }

--- a/PokeSoulLinkBot/Application/Services/PokeApiPokemonNameResolver.cs
+++ b/PokeSoulLinkBot/Application/Services/PokeApiPokemonNameResolver.cs
@@ -20,6 +20,7 @@ public sealed class PokeApiPokemonNameResolver : IPokemonNameResolver
 
     private readonly SemaphoreSlim indexLock = new SemaphoreSlim(1, 1);
     private readonly HttpClient httpClient;
+    private readonly PokemonDataCacheStore? pokemonDataCacheStore;
     private readonly ConcurrentDictionary<string, string> resolvedNameCache =
         new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -29,12 +30,16 @@ public sealed class PokeApiPokemonNameResolver : IPokemonNameResolver
     /// Initializes a new instance of the <see cref="PokeApiPokemonNameResolver"/> class.
     /// </summary>
     /// <param name="httpClient">The HTTP client.</param>
+    /// <param name="pokemonDataCacheStore">The optional persistent Pokémon data cache.</param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="httpClient"/> is <see langword="null"/>.
     /// </exception>
-    public PokeApiPokemonNameResolver(HttpClient httpClient)
+    public PokeApiPokemonNameResolver(
+        HttpClient httpClient,
+        PokemonDataCacheStore? pokemonDataCacheStore = null)
     {
         this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        this.pokemonDataCacheStore = pokemonDataCacheStore;
     }
 
     /// <inheritdoc />
@@ -64,6 +69,15 @@ public sealed class PokeApiPokemonNameResolver : IPokemonNameResolver
 
         this.resolvedNameCache.TryAdd(lookupKey, resolvedName);
         return resolvedName;
+    }
+
+    /// <summary>
+    /// Warms the localized Pokémon name index.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    public async Task WarmUpAsync()
+    {
+        _ = await this.GetLocalizedNameIndexAsync();
     }
 
     private void AddSpeciesNames(Dictionary<string, string> index, PokemonSpeciesDto species)
@@ -181,7 +195,24 @@ public sealed class PokeApiPokemonNameResolver : IPokemonNameResolver
                 return this.localizedNameIndex;
             }
 
+            IReadOnlyDictionary<string, string>? persistedIndex = this.pokemonDataCacheStore is null
+                ? null
+                : await this.pokemonDataCacheStore.GetNameIndexAsync();
+            if (persistedIndex is not null && persistedIndex.Count > 0)
+            {
+                Log.Information(
+                    "Using Pokemon localized name index from persistent cache with {NameCount} names.",
+                    persistedIndex.Count);
+                this.localizedNameIndex = persistedIndex;
+                return this.localizedNameIndex;
+            }
+
             this.localizedNameIndex = await this.BuildLocalizedNameIndexAsync();
+            if (this.pokemonDataCacheStore is not null)
+            {
+                await this.pokemonDataCacheStore.SaveNameIndexAsync(this.localizedNameIndex);
+            }
+
             return this.localizedNameIndex;
         }
         finally

--- a/PokeSoulLinkBot/Application/Services/PokemonDataCacheStore.cs
+++ b/PokeSoulLinkBot/Application/Services/PokemonDataCacheStore.cs
@@ -1,0 +1,298 @@
+using System.Text.Json;
+using PokeSoulLinkBot.Core.Models;
+using Serilog;
+
+namespace PokeSoulLinkBot.Application.Services;
+
+/// <summary>
+/// Loads and saves locally cached Pokémon data used by PokéAPI-backed services.
+/// </summary>
+public sealed class PokemonDataCacheStore
+{
+    private const int CurrentVersion = 1;
+
+    private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+
+    private readonly string cacheFilePath;
+    private readonly SemaphoreSlim cacheLock = new SemaphoreSlim(1, 1);
+    private PokemonDataCache? cache;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PokemonDataCacheStore"/> class.
+    /// </summary>
+    /// <param name="cacheFilePath">The local cache file path.</param>
+    public PokemonDataCacheStore(string cacheFilePath)
+    {
+        this.cacheFilePath = cacheFilePath ?? throw new ArgumentNullException(nameof(cacheFilePath));
+    }
+
+    /// <summary>
+    /// Loads the cache file into memory if it exists.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    public async Task InitializeAsync()
+    {
+        _ = await this.GetCacheAsync();
+    }
+
+    /// <summary>
+    /// Gets the cached localized name index.
+    /// </summary>
+    /// <returns>The cached index, or <see langword="null"/> when no index exists.</returns>
+    public async Task<IReadOnlyDictionary<string, string>?> GetNameIndexAsync()
+    {
+        _ = await this.GetCacheAsync();
+        await this.cacheLock.WaitAsync();
+        try
+        {
+            if (this.cache!.NameIndex.Count == 0)
+            {
+                return null;
+            }
+
+            return new Dictionary<string, string>(
+                this.cache.NameIndex,
+                StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            this.cacheLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Saves the localized name index to the persistent cache.
+    /// </summary>
+    /// <param name="nameIndex">The name index to save.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    public async Task SaveNameIndexAsync(IReadOnlyDictionary<string, string> nameIndex)
+    {
+        ArgumentNullException.ThrowIfNull(nameIndex);
+
+        await this.UpdateCacheAsync(cache =>
+        {
+            cache.NameIndex = new Dictionary<string, string>(nameIndex, StringComparer.OrdinalIgnoreCase);
+        });
+    }
+
+    /// <summary>
+    /// Gets cached Pokémon metadata.
+    /// </summary>
+    /// <param name="pokemonName">The normalized Pokémon name.</param>
+    /// <returns>The cached Pokémon metadata, or <see langword="null"/>.</returns>
+    public async Task<PokemonInfo?> GetPokemonInfoAsync(string pokemonName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pokemonName);
+
+        _ = await this.GetCacheAsync();
+        await this.cacheLock.WaitAsync();
+        try
+        {
+            return this.cache!.PokemonInfos.TryGetValue(NormalizeKey(pokemonName), out PokemonInfo? cachedInfo)
+                ? cachedInfo
+                : null;
+        }
+        finally
+        {
+            this.cacheLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Saves Pokémon metadata to the persistent cache.
+    /// </summary>
+    /// <param name="pokemonName">The normalized Pokémon name.</param>
+    /// <param name="pokemonInfo">The Pokémon metadata.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    public async Task SavePokemonInfoAsync(string pokemonName, PokemonInfo pokemonInfo)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pokemonName);
+        ArgumentNullException.ThrowIfNull(pokemonInfo);
+
+        await this.UpdateCacheAsync(cache =>
+        {
+            cache.PokemonInfos[NormalizeKey(pokemonName)] = pokemonInfo;
+        });
+    }
+
+    /// <summary>
+    /// Gets a cached Pokédex entry.
+    /// </summary>
+    /// <param name="pokemonName">The normalized Pokémon name.</param>
+    /// <returns>The cached Pokédex entry, or <see langword="null"/>.</returns>
+    public async Task<PokedexEntry?> GetPokedexEntryAsync(string pokemonName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pokemonName);
+
+        _ = await this.GetCacheAsync();
+        await this.cacheLock.WaitAsync();
+        try
+        {
+            return this.cache!.PokedexEntries.TryGetValue(NormalizeKey(pokemonName), out PokedexEntry? cachedEntry)
+                ? cachedEntry
+                : null;
+        }
+        finally
+        {
+            this.cacheLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Saves a Pokédex entry to the persistent cache.
+    /// </summary>
+    /// <param name="pokemonName">The normalized Pokémon name.</param>
+    /// <param name="pokedexEntry">The Pokédex entry.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    public async Task SavePokedexEntryAsync(string pokemonName, PokedexEntry pokedexEntry)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pokemonName);
+        ArgumentNullException.ThrowIfNull(pokedexEntry);
+
+        await this.UpdateCacheAsync(cache =>
+        {
+            cache.PokedexEntries[NormalizeKey(pokemonName)] = pokedexEntry;
+        });
+    }
+
+    private static string NormalizeKey(string value)
+    {
+        return value.Trim().ToLowerInvariant();
+    }
+
+    private static bool IsCacheIoException(Exception exception)
+    {
+        return exception is IOException or UnauthorizedAccessException or NotSupportedException;
+    }
+
+    private static PokemonDataCache NormalizeCache(PokemonDataCache cache)
+    {
+        cache.Version = CurrentVersion;
+        cache.NameIndex = new Dictionary<string, string>(
+            cache.NameIndex ?? new Dictionary<string, string>(),
+            StringComparer.OrdinalIgnoreCase);
+        cache.PokemonInfos = new Dictionary<string, PokemonInfo>(
+            cache.PokemonInfos ?? new Dictionary<string, PokemonInfo>(),
+            StringComparer.OrdinalIgnoreCase);
+        cache.PokedexEntries = new Dictionary<string, PokedexEntry>(
+            cache.PokedexEntries ?? new Dictionary<string, PokedexEntry>(),
+            StringComparer.OrdinalIgnoreCase);
+
+        return cache;
+    }
+
+    private async Task<PokemonDataCache> GetCacheAsync()
+    {
+        if (this.cache is not null)
+        {
+            return this.cache;
+        }
+
+        await this.cacheLock.WaitAsync();
+        try
+        {
+            if (this.cache is not null)
+            {
+                return this.cache;
+            }
+
+            this.cache = await this.LoadCacheAsync() ?? new PokemonDataCache
+            {
+                Version = CurrentVersion,
+                RefreshedAtUtc = DateTime.UtcNow,
+            };
+            return this.cache;
+        }
+        finally
+        {
+            this.cacheLock.Release();
+        }
+    }
+
+    private async Task<PokemonDataCache?> LoadCacheAsync()
+    {
+        if (!File.Exists(this.cacheFilePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            await using var stream = File.OpenRead(this.cacheFilePath);
+            PokemonDataCache? loadedCache = await JsonSerializer.DeserializeAsync<PokemonDataCache>(stream, JsonOptions);
+            return loadedCache is null ? null : NormalizeCache(loadedCache);
+        }
+        catch (JsonException exception)
+        {
+            Log.Warning(exception, "Pokemon data cache could not be read from {CacheFilePath}.", this.cacheFilePath);
+            return null;
+        }
+        catch (Exception exception) when (IsCacheIoException(exception))
+        {
+            Log.Warning(exception, "Pokemon data cache could not be opened from {CacheFilePath}.", this.cacheFilePath);
+            return null;
+        }
+    }
+
+    private async Task UpdateCacheAsync(Action<PokemonDataCache> update)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+
+        PokemonDataCache currentCache = await this.GetCacheAsync();
+        await this.cacheLock.WaitAsync();
+        try
+        {
+            update(currentCache);
+            currentCache.Version = CurrentVersion;
+            currentCache.RefreshedAtUtc = DateTime.UtcNow;
+            await this.SaveCacheAsync(currentCache);
+        }
+        finally
+        {
+            this.cacheLock.Release();
+        }
+    }
+
+    private async Task SaveCacheAsync(PokemonDataCache currentCache)
+    {
+        string? directoryPath = Path.GetDirectoryName(this.cacheFilePath);
+        if (!string.IsNullOrWhiteSpace(directoryPath))
+        {
+            Directory.CreateDirectory(directoryPath);
+        }
+
+        string tempFilePath = this.CreateTempFilePath(directoryPath);
+
+        try
+        {
+            await using (var stream = File.Create(tempFilePath))
+            {
+                await JsonSerializer.SerializeAsync(stream, currentCache, JsonOptions);
+            }
+
+            File.Move(tempFilePath, this.cacheFilePath, overwrite: true);
+        }
+        catch (Exception exception) when (IsCacheIoException(exception))
+        {
+            Log.Warning(exception, "Pokemon data cache could not be saved to {CacheFilePath}.", this.cacheFilePath);
+        }
+        finally
+        {
+            if (File.Exists(tempFilePath))
+            {
+                File.Delete(tempFilePath);
+            }
+        }
+    }
+
+    private string CreateTempFilePath(string? directoryPath)
+    {
+        string fileName = $"{Path.GetFileName(this.cacheFilePath)}.{Guid.NewGuid():N}.tmp";
+        return string.IsNullOrWhiteSpace(directoryPath)
+            ? fileName
+            : Path.Combine(directoryPath, fileName);
+    }
+}

--- a/PokeSoulLinkBot/Bot/Program.cs
+++ b/PokeSoulLinkBot/Bot/Program.cs
@@ -52,6 +52,11 @@ internal sealed class Program
             "PokeSoulLinkBot",
             "Data",
             "game-data-catalog.json");
+        var pokemonDataCachePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "PokeSoulLinkBot",
+            "Data",
+            "pokemon-data-cache.json");
         var resourcesDirectoryPath = Path.Combine(AppContext.BaseDirectory, "Resources");
         var httpClient = new HttpClient
         {
@@ -59,9 +64,13 @@ internal sealed class Program
             Timeout = TimeSpan.FromSeconds(5),
         };
 
-        var pokemonNameResolver = new PokeApiPokemonNameResolver(httpClient);
-        var pokemonLookupService = new PokeApiPokemonLookupService(httpClient, pokemonNameResolver);
-        var pokedexService = new PokeApiPokedexService(httpClient, pokemonNameResolver);
+        var pokemonDataCacheStore = new PokemonDataCacheStore(pokemonDataCachePath);
+        var pokemonNameResolver = new PokeApiPokemonNameResolver(httpClient, pokemonDataCacheStore);
+        var pokemonLookupService = new PokeApiPokemonLookupService(
+            httpClient,
+            pokemonNameResolver,
+            pokemonDataCacheStore);
+        var pokedexService = new PokeApiPokedexService(httpClient, pokemonNameResolver, pokemonDataCacheStore);
         var pokedexPresenter = new PokedexPresenter();
         var arenaInfoService = new PokemonDbArenaInfoService(httpClient);
         var gameDataCatalogService = new PokeApiGameDataCatalogService(httpClient, gameDataCachePath);
@@ -115,6 +124,8 @@ internal sealed class Program
 
                 await RegisterSlashCommandsAsync(definitions);
 
+                _ = Task.Run(WarmPokemonDataCacheAsync);
+
                 Log.Information("Initializing game data catalog.");
                 await gameDataCatalogService.InitializeAsync();
                 Log.Information("Game data catalog initialization completed.");
@@ -126,6 +137,21 @@ internal sealed class Program
             catch (Exception exception)
             {
                 Log.Error(exception, "Ready startup failed.");
+            }
+        }
+
+        async Task WarmPokemonDataCacheAsync()
+        {
+            try
+            {
+                Log.Information("Warming Pokemon data cache.");
+                await pokemonDataCacheStore.InitializeAsync();
+                await pokemonNameResolver.WarmUpAsync();
+                Log.Information("Pokemon data cache warmup completed.");
+            }
+            catch (Exception exception)
+            {
+                Log.Warning(exception, "Pokemon data cache warmup failed.");
             }
         }
 

--- a/PokeSoulLinkBot/Core/Models/PokemonDataCache.cs
+++ b/PokeSoulLinkBot/Core/Models/PokemonDataCache.cs
@@ -1,0 +1,35 @@
+namespace PokeSoulLinkBot.Core.Models;
+
+/// <summary>
+/// Represents locally cached Pokémon data that can be reused across bot restarts.
+/// </summary>
+public sealed class PokemonDataCache
+{
+    /// <summary>
+    /// Gets or sets the cache schema version.
+    /// </summary>
+    public int Version { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets the UTC date and time when the cache was last refreshed.
+    /// </summary>
+    public DateTime RefreshedAtUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets normalized localized names mapped to PokéAPI species names.
+    /// </summary>
+    public Dictionary<string, string> NameIndex { get; set; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets or sets cached Pokémon metadata by normalized PokéAPI name.
+    /// </summary>
+    public Dictionary<string, PokemonInfo> PokemonInfos { get; set; } =
+        new Dictionary<string, PokemonInfo>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets or sets cached Pokédex entries by normalized PokéAPI name.
+    /// </summary>
+    public Dictionary<string, PokedexEntry> PokedexEntries { get; set; } =
+        new Dictionary<string, PokedexEntry>(StringComparer.OrdinalIgnoreCase);
+}


### PR DESCRIPTION
Ticket: https://github.com/mpiechot/PokemonSoulLinkDiscord/issues/40

## Summary
- Add a versioned persistent Pokemon data cache with `RefreshedAtUtc` metadata.
- Reuse cached localized name indexes, Pokemon metadata, and Pokedex entries across bot restarts.
- Persist successful PokeAPI lookups back to the cache and use stale cached data when available.
- Warm the Pokemon name cache in the background after Discord ready without blocking startup tasks.
- Add tests for persisted name index hits, persisted Pokemon info hits, cache refresh after API success, and persisted Pokedex hits.

Closes #40

## Verification
- `dotnet build PokeSoulLinkBot\PokeSoulLinkBot.csproj --no-restore --verbosity minimal`
- `dotnet test PokeSoulLinkBot.Tests\PokeSoulLinkBot.Tests.csproj --no-restore --verbosity minimal`