### PR TITLE
Skip unchanged slash command registration

### DIFF
--- a/PokeSoulLinkBot.Tests/SlashCommandRegistrationServiceTests.cs
+++ b/PokeSoulLinkBot.Tests/SlashCommandRegistrationServiceTests.cs
@@ -1,0 +1,109 @@
+using Discord;
+using PokeSoulLinkBot.Bot.Registration;
+using Xunit;
+
+namespace PokeSoulLinkBot.Tests;
+
+public sealed class SlashCommandRegistrationServiceTests
+{
+    [Fact]
+    public async Task RegisterAsync_ShouldSkipOverwriteWhenDefinitionsAreUnchanged()
+    {
+        ApplicationCommandProperties[] definitions = CreateDefinitions("Shows the current run status.");
+        IReadOnlyCollection<SlashCommandDefinitionSnapshot> remoteSnapshots =
+            SlashCommandRegistrationService.CreateLocalSnapshots(definitions);
+        var target = new FakeRegistrationTarget(remoteSnapshots);
+        var service = new SlashCommandRegistrationService();
+
+        await service.RegisterAsync(definitions, new[] { target });
+
+        Assert.Equal(0, target.BulkOverwriteCount);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ShouldOverwriteWhenDefinitionsChanged()
+    {
+        ApplicationCommandProperties[] definitions = CreateDefinitions("Shows the current run status.");
+        var remoteSnapshots = new[]
+        {
+            new SlashCommandDefinitionSnapshot
+            {
+                Type = ApplicationCommandType.Slash,
+                Name = "status",
+                Description = "Old description.",
+            },
+        };
+        var target = new FakeRegistrationTarget(remoteSnapshots);
+        var service = new SlashCommandRegistrationService();
+
+        await service.RegisterAsync(definitions, new[] { target });
+
+        Assert.Equal(1, target.BulkOverwriteCount);
+        Assert.NotNull(target.LastDefinitions);
+        Assert.Equal(definitions.Select(definition => definition.Name.Value), target.LastDefinitions.Select(definition => definition.Name.Value));
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ShouldContinueWhenOneTargetFails()
+    {
+        ApplicationCommandProperties[] definitions = CreateDefinitions("Shows the current run status.");
+        var failingTarget = new FakeRegistrationTarget(Array.Empty<SlashCommandDefinitionSnapshot>())
+        {
+            ThrowOnRead = true,
+        };
+        var changedTarget = new FakeRegistrationTarget(Array.Empty<SlashCommandDefinitionSnapshot>());
+        var service = new SlashCommandRegistrationService();
+
+        await service.RegisterAsync(definitions, new[] { failingTarget, changedTarget });
+
+        Assert.Equal(0, failingTarget.BulkOverwriteCount);
+        Assert.Equal(1, changedTarget.BulkOverwriteCount);
+    }
+
+    private static ApplicationCommandProperties[] CreateDefinitions(string description)
+    {
+        return new[]
+        {
+            new SlashCommandBuilder()
+                .WithName("status")
+                .WithDescription(description)
+                .AddOption("verbose", ApplicationCommandOptionType.Boolean, "Show more details.", isRequired: false)
+                .Build(),
+        };
+    }
+
+    private sealed class FakeRegistrationTarget : ISlashCommandRegistrationTarget
+    {
+        private readonly IReadOnlyCollection<SlashCommandDefinitionSnapshot> remoteSnapshots;
+
+        public FakeRegistrationTarget(IReadOnlyCollection<SlashCommandDefinitionSnapshot> remoteSnapshots)
+        {
+            this.remoteSnapshots = remoteSnapshots;
+        }
+
+        public string DisplayName => "fake target";
+
+        public int BulkOverwriteCount { get; private set; }
+
+        public ApplicationCommandProperties[]? LastDefinitions { get; private set; }
+
+        public bool ThrowOnRead { get; set; }
+
+        public Task<IReadOnlyCollection<SlashCommandDefinitionSnapshot>> GetRemoteCommandSnapshotsAsync()
+        {
+            if (this.ThrowOnRead)
+            {
+                throw new InvalidOperationException("Discord is temporarily unavailable.");
+            }
+
+            return Task.FromResult(this.remoteSnapshots);
+        }
+
+        public Task BulkOverwriteAsync(ApplicationCommandProperties[] definitions)
+        {
+            this.BulkOverwriteCount++;
+            this.LastDefinitions = definitions;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/PokeSoulLinkBot/Bot/Program.cs
+++ b/PokeSoulLinkBot/Bot/Program.cs
@@ -7,6 +7,7 @@ using PokeSoulLinkBot.Bot.Commands;
 using PokeSoulLinkBot.Bot.Factories;
 using PokeSoulLinkBot.Bot.Handlers;
 using PokeSoulLinkBot.Bot.Presentation;
+using PokeSoulLinkBot.Bot.Registration;
 using PokeSoulLinkBot.Infrastructure.Persistence;
 using Serilog;
 using Serilog.Events;
@@ -90,6 +91,7 @@ internal sealed class Program
         };
 
         var slashCommandRouter = new SlashCommandRouter(commands, embedFactory);
+        var slashCommandRegistrationService = new SlashCommandRegistrationService();
         var readyStartupTaskRunner = new ReadyStartupTaskRunner(RegisterCommandsAfterReadyAsync);
 
         client.Log += OnLogAsync;
@@ -132,27 +134,81 @@ internal sealed class Program
         async Task RegisterSlashCommandsAsync(IReadOnlyCollection<ApplicationCommandProperties> definitions)
         {
             var commandDefinitions = definitions.ToArray();
+            var registrationTargets = CreateRegistrationTargets();
 
-            Log.Information("Registering {CommandCount} global slash commands.", commandDefinitions.Length);
-            await client.BulkOverwriteGlobalApplicationCommandsAsync(commandDefinitions);
-            Log.Information("Registered {CommandCount} global slash commands.", commandDefinitions.Length);
+            await slashCommandRegistrationService.RegisterAsync(commandDefinitions, registrationTargets);
+        }
+
+        IReadOnlyCollection<ISlashCommandRegistrationTarget> CreateRegistrationTargets()
+        {
+            var registrationMode = (configuration["DISCORD_COMMAND_REGISTRATION_MODE"] ?? "all")
+                .Trim()
+                .ToLowerInvariant();
+            var configuredGuildIds = ParseGuildIds(configuration["DISCORD_COMMAND_GUILD_IDS"]);
+            var targets = new List<ISlashCommandRegistrationTarget>();
+
+            if (ShouldRegisterGlobalCommands(registrationMode))
+            {
+                targets.Add(new SlashCommandRegistrationTarget(
+                    "global commands",
+                    async () => (await client.GetGlobalApplicationCommandsAsync()).Cast<IApplicationCommand>().ToList(),
+                    async definitions => await client.BulkOverwriteGlobalApplicationCommandsAsync(definitions)));
+            }
+
+            if (!ShouldRegisterGuildCommands(registrationMode))
+            {
+                return targets;
+            }
 
             foreach (var guild in client.Guilds)
             {
-                Log.Information(
-                    "Registering {CommandCount} slash commands for guild {GuildName} ({GuildId}).",
-                    commandDefinitions.Length,
-                    guild.Name,
-                    guild.Id);
+                if (configuredGuildIds.Count > 0 && !configuredGuildIds.Contains(guild.Id))
+                {
+                    continue;
+                }
 
-                await guild.BulkOverwriteApplicationCommandAsync(commandDefinitions);
-
-                Log.Information(
-                    "Registered {CommandCount} slash commands for guild {GuildName} ({GuildId}).",
-                    commandDefinitions.Length,
-                    guild.Name,
-                    guild.Id);
+                targets.Add(new SlashCommandRegistrationTarget(
+                    $"guild {guild.Name} ({guild.Id})",
+                    async () => (await guild.GetApplicationCommandsAsync()).Cast<IApplicationCommand>().ToList(),
+                    async definitions => await guild.BulkOverwriteApplicationCommandAsync(definitions)));
             }
+
+            return targets;
+        }
+
+        static bool ShouldRegisterGlobalCommands(string registrationMode)
+        {
+            return registrationMode is "all" or "global";
+        }
+
+        static bool ShouldRegisterGuildCommands(string registrationMode)
+        {
+            return registrationMode is "all" or "guild" or "guilds" or "development";
+        }
+
+        static IReadOnlySet<ulong> ParseGuildIds(string? guildIds)
+        {
+            var parsedGuildIds = new HashSet<ulong>();
+            if (string.IsNullOrWhiteSpace(guildIds))
+            {
+                return parsedGuildIds;
+            }
+
+            foreach (var value in guildIds.Split(
+                new[] { ',', ';', ' ' },
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (ulong.TryParse(value, out ulong guildId))
+                {
+                    parsedGuildIds.Add(guildId);
+                }
+                else
+                {
+                    Log.Warning("Ignoring invalid Discord guild id '{GuildId}' in DISCORD_COMMAND_GUILD_IDS.", value);
+                }
+            }
+
+            return parsedGuildIds;
         }
     }
 

--- a/PokeSoulLinkBot/Bot/Registration/ISlashCommandRegistrationTarget.cs
+++ b/PokeSoulLinkBot/Bot/Registration/ISlashCommandRegistrationTarget.cs
@@ -1,0 +1,27 @@
+using Discord;
+
+namespace PokeSoulLinkBot.Bot.Registration;
+
+/// <summary>
+/// Represents a Discord location where slash commands can be registered.
+/// </summary>
+public interface ISlashCommandRegistrationTarget
+{
+    /// <summary>
+    /// Gets the display name used in logs.
+    /// </summary>
+    string DisplayName { get; }
+
+    /// <summary>
+    /// Gets remote command snapshots for this target.
+    /// </summary>
+    /// <returns>The remote command snapshots.</returns>
+    Task<IReadOnlyCollection<SlashCommandDefinitionSnapshot>> GetRemoteCommandSnapshotsAsync();
+
+    /// <summary>
+    /// Replaces remote commands for this target.
+    /// </summary>
+    /// <param name="definitions">The local command definitions.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task BulkOverwriteAsync(ApplicationCommandProperties[] definitions);
+}

--- a/PokeSoulLinkBot/Bot/Registration/SlashCommandDefinitionSnapshot.cs
+++ b/PokeSoulLinkBot/Bot/Registration/SlashCommandDefinitionSnapshot.cs
@@ -1,0 +1,106 @@
+using Discord;
+
+namespace PokeSoulLinkBot.Bot.Registration;
+
+/// <summary>
+/// Represents the stable parts of a slash command definition.
+/// </summary>
+public sealed class SlashCommandDefinitionSnapshot : IEquatable<SlashCommandDefinitionSnapshot>
+{
+    /// <summary>
+    /// Gets or sets the command type.
+    /// </summary>
+    public ApplicationCommandType Type { get; set; } = ApplicationCommandType.Slash;
+
+    /// <summary>
+    /// Gets or sets the command name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the command description.
+    /// </summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets option snapshots.
+    /// </summary>
+    public List<SlashCommandOptionSnapshot> Options { get; set; } = new List<SlashCommandOptionSnapshot>();
+
+    /// <summary>
+    /// Creates a snapshot from local Discord.Net command properties.
+    /// </summary>
+    /// <param name="definition">The local command definition.</param>
+    /// <returns>The created snapshot.</returns>
+    public static SlashCommandDefinitionSnapshot FromDefinition(ApplicationCommandProperties definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        var slashDefinition = definition as SlashCommandProperties
+            ?? throw new InvalidOperationException("Only slash command definitions can be registered.");
+
+        return new SlashCommandDefinitionSnapshot
+        {
+            Type = ApplicationCommandType.Slash,
+            Name = slashDefinition.Name.Value,
+            Description = slashDefinition.Description.Value,
+            Options = slashDefinition.Options.IsSpecified
+                ? slashDefinition.Options.Value.Select(SlashCommandOptionSnapshot.FromDefinition).ToList()
+                : new List<SlashCommandOptionSnapshot>(),
+        };
+    }
+
+    /// <summary>
+    /// Creates a snapshot from a remote Discord command.
+    /// </summary>
+    /// <param name="command">The remote command.</param>
+    /// <returns>The created snapshot.</returns>
+    public static SlashCommandDefinitionSnapshot FromRemote(IApplicationCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        return new SlashCommandDefinitionSnapshot
+        {
+            Type = command.Type,
+            Name = command.Name,
+            Description = command.Description,
+            Options = command.Options.Select(SlashCommandOptionSnapshot.FromRemote).ToList(),
+        };
+    }
+
+    /// <inheritdoc />
+    public bool Equals(SlashCommandDefinitionSnapshot? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return this.Type == other.Type
+            && string.Equals(this.Name, other.Name, StringComparison.Ordinal)
+            && string.Equals(this.Description, other.Description, StringComparison.Ordinal)
+            && this.Options.SequenceEqual(other.Options);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is SlashCommandDefinitionSnapshot other && this.Equals(other);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        var hashCode = default(HashCode);
+        hashCode.Add(this.Type);
+        hashCode.Add(this.Name, StringComparer.Ordinal);
+        hashCode.Add(this.Description, StringComparer.Ordinal);
+
+        foreach (SlashCommandOptionSnapshot option in this.Options)
+        {
+            hashCode.Add(option);
+        }
+
+        return hashCode.ToHashCode();
+    }
+}

--- a/PokeSoulLinkBot/Bot/Registration/SlashCommandOptionSnapshot.cs
+++ b/PokeSoulLinkBot/Bot/Registration/SlashCommandOptionSnapshot.cs
@@ -1,0 +1,119 @@
+using Discord;
+
+namespace PokeSoulLinkBot.Bot.Registration;
+
+/// <summary>
+/// Represents the stable parts of a slash command option definition.
+/// </summary>
+public sealed class SlashCommandOptionSnapshot : IEquatable<SlashCommandOptionSnapshot>
+{
+    /// <summary>
+    /// Gets or sets the option type.
+    /// </summary>
+    public ApplicationCommandOptionType Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets the option name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the option description.
+    /// </summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the option is required.
+    /// </summary>
+    public bool IsRequired { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the option has autocomplete enabled.
+    /// </summary>
+    public bool IsAutocomplete { get; set; }
+
+    /// <summary>
+    /// Gets or sets nested option snapshots.
+    /// </summary>
+    public List<SlashCommandOptionSnapshot> Options { get; set; } = new List<SlashCommandOptionSnapshot>();
+
+    /// <summary>
+    /// Creates a snapshot from local Discord.Net option properties.
+    /// </summary>
+    /// <param name="option">The local option definition.</param>
+    /// <returns>The created snapshot.</returns>
+    public static SlashCommandOptionSnapshot FromDefinition(ApplicationCommandOptionProperties option)
+    {
+        ArgumentNullException.ThrowIfNull(option);
+
+        return new SlashCommandOptionSnapshot
+        {
+            Type = option.Type,
+            Name = option.Name,
+            Description = option.Description,
+            IsRequired = option.IsRequired == true,
+            IsAutocomplete = option.IsAutocomplete,
+            Options = option.Options.Select(FromDefinition).ToList(),
+        };
+    }
+
+    /// <summary>
+    /// Creates a snapshot from a remote Discord command option.
+    /// </summary>
+    /// <param name="option">The remote option.</param>
+    /// <returns>The created snapshot.</returns>
+    public static SlashCommandOptionSnapshot FromRemote(IApplicationCommandOption option)
+    {
+        ArgumentNullException.ThrowIfNull(option);
+
+        return new SlashCommandOptionSnapshot
+        {
+            Type = option.Type,
+            Name = option.Name,
+            Description = option.Description,
+            IsRequired = option.IsRequired == true,
+            IsAutocomplete = option.IsAutocomplete == true,
+            Options = option.Options.Select(FromRemote).ToList(),
+        };
+    }
+
+    /// <inheritdoc />
+    public bool Equals(SlashCommandOptionSnapshot? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return this.Type == other.Type
+            && string.Equals(this.Name, other.Name, StringComparison.Ordinal)
+            && string.Equals(this.Description, other.Description, StringComparison.Ordinal)
+            && this.IsRequired == other.IsRequired
+            && this.IsAutocomplete == other.IsAutocomplete
+            && this.Options.SequenceEqual(other.Options);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is SlashCommandOptionSnapshot other && this.Equals(other);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        var hashCode = default(HashCode);
+        hashCode.Add(this.Type);
+        hashCode.Add(this.Name, StringComparer.Ordinal);
+        hashCode.Add(this.Description, StringComparer.Ordinal);
+        hashCode.Add(this.IsRequired);
+        hashCode.Add(this.IsAutocomplete);
+
+        foreach (SlashCommandOptionSnapshot option in this.Options)
+        {
+            hashCode.Add(option);
+        }
+
+        return hashCode.ToHashCode();
+    }
+}

--- a/PokeSoulLinkBot/Bot/Registration/SlashCommandRegistrationService.cs
+++ b/PokeSoulLinkBot/Bot/Registration/SlashCommandRegistrationService.cs
@@ -1,0 +1,100 @@
+using Discord;
+using Serilog;
+
+namespace PokeSoulLinkBot.Bot.Registration;
+
+/// <summary>
+/// Registers slash commands only when local definitions differ from Discord's remote definitions.
+/// </summary>
+public sealed class SlashCommandRegistrationService
+{
+    /// <summary>
+    /// Creates comparable snapshots from local command definitions.
+    /// </summary>
+    /// <param name="definitions">The local command definitions.</param>
+    /// <returns>The local snapshots.</returns>
+    public static IReadOnlyCollection<SlashCommandDefinitionSnapshot> CreateLocalSnapshots(
+        IReadOnlyCollection<ApplicationCommandProperties> definitions)
+    {
+        ArgumentNullException.ThrowIfNull(definitions);
+
+        return definitions
+            .Select(SlashCommandDefinitionSnapshot.FromDefinition)
+            .OrderBy(snapshot => snapshot.Name, StringComparer.Ordinal)
+            .ThenBy(snapshot => snapshot.Type)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Compares local and remote command snapshots.
+    /// </summary>
+    /// <param name="localSnapshots">The local snapshots.</param>
+    /// <param name="remoteSnapshots">The remote snapshots.</param>
+    /// <returns><see langword="true"/> when the snapshots match; otherwise, <see langword="false"/>.</returns>
+    public static bool DefinitionsMatch(
+        IReadOnlyCollection<SlashCommandDefinitionSnapshot> localSnapshots,
+        IReadOnlyCollection<SlashCommandDefinitionSnapshot> remoteSnapshots)
+    {
+        ArgumentNullException.ThrowIfNull(localSnapshots);
+        ArgumentNullException.ThrowIfNull(remoteSnapshots);
+
+        var orderedRemoteSnapshots = remoteSnapshots
+            .OrderBy(snapshot => snapshot.Name, StringComparer.Ordinal)
+            .ThenBy(snapshot => snapshot.Type)
+            .ToList();
+
+        return localSnapshots.SequenceEqual(orderedRemoteSnapshots);
+    }
+
+    /// <summary>
+    /// Registers slash commands for all provided targets.
+    /// </summary>
+    /// <param name="definitions">The local command definitions.</param>
+    /// <param name="targets">The registration targets.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    public async Task RegisterAsync(
+        IReadOnlyCollection<ApplicationCommandProperties> definitions,
+        IReadOnlyCollection<ISlashCommandRegistrationTarget> targets)
+    {
+        ArgumentNullException.ThrowIfNull(definitions);
+        ArgumentNullException.ThrowIfNull(targets);
+
+        if (targets.Count == 0)
+        {
+            Log.Warning("Slash command registration has no configured targets.");
+            return;
+        }
+
+        ApplicationCommandProperties[] commandDefinitions = definitions.ToArray();
+        IReadOnlyCollection<SlashCommandDefinitionSnapshot> localSnapshots = CreateLocalSnapshots(commandDefinitions);
+
+        foreach (ISlashCommandRegistrationTarget target in targets)
+        {
+            try
+            {
+                IReadOnlyCollection<SlashCommandDefinitionSnapshot> remoteSnapshots =
+                    await target.GetRemoteCommandSnapshotsAsync();
+
+                if (DefinitionsMatch(localSnapshots, remoteSnapshots))
+                {
+                    Log.Information("Slash commands are unchanged for {RegistrationTarget}. Skipping overwrite.", target.DisplayName);
+                    continue;
+                }
+
+                Log.Information(
+                    "Registering {CommandCount} slash commands for {RegistrationTarget}.",
+                    commandDefinitions.Length,
+                    target.DisplayName);
+                await target.BulkOverwriteAsync(commandDefinitions);
+                Log.Information(
+                    "Registered {CommandCount} slash commands for {RegistrationTarget}.",
+                    commandDefinitions.Length,
+                    target.DisplayName);
+            }
+            catch (Exception exception)
+            {
+                Log.Warning(exception, "Slash command registration failed for {RegistrationTarget}.", target.DisplayName);
+            }
+        }
+    }
+}

--- a/PokeSoulLinkBot/Bot/Registration/SlashCommandRegistrationTarget.cs
+++ b/PokeSoulLinkBot/Bot/Registration/SlashCommandRegistrationTarget.cs
@@ -1,0 +1,47 @@
+using Discord;
+
+namespace PokeSoulLinkBot.Bot.Registration;
+
+/// <summary>
+/// Provides a delegate-backed slash command registration target.
+/// </summary>
+public sealed class SlashCommandRegistrationTarget : ISlashCommandRegistrationTarget
+{
+    private readonly Func<Task<IReadOnlyCollection<IApplicationCommand>>> getRemoteCommandsAsync;
+    private readonly Func<ApplicationCommandProperties[], Task> bulkOverwriteAsync;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SlashCommandRegistrationTarget"/> class.
+    /// </summary>
+    /// <param name="displayName">The display name used in logs.</param>
+    /// <param name="getRemoteCommandsAsync">The remote command loader.</param>
+    /// <param name="bulkOverwriteAsync">The bulk overwrite operation.</param>
+    public SlashCommandRegistrationTarget(
+        string displayName,
+        Func<Task<IReadOnlyCollection<IApplicationCommand>>> getRemoteCommandsAsync,
+        Func<ApplicationCommandProperties[], Task> bulkOverwriteAsync)
+    {
+        this.DisplayName = displayName;
+        this.getRemoteCommandsAsync = getRemoteCommandsAsync ?? throw new ArgumentNullException(nameof(getRemoteCommandsAsync));
+        this.bulkOverwriteAsync = bulkOverwriteAsync ?? throw new ArgumentNullException(nameof(bulkOverwriteAsync));
+    }
+
+    /// <inheritdoc />
+    public string DisplayName { get; }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyCollection<SlashCommandDefinitionSnapshot>> GetRemoteCommandSnapshotsAsync()
+    {
+        IReadOnlyCollection<IApplicationCommand> commands = await this.getRemoteCommandsAsync();
+        return commands
+            .Where(command => command.Type == ApplicationCommandType.Slash)
+            .Select(SlashCommandDefinitionSnapshot.FromRemote)
+            .ToList();
+    }
+
+    /// <inheritdoc />
+    public Task BulkOverwriteAsync(ApplicationCommandProperties[] definitions)
+    {
+        return this.bulkOverwriteAsync(definitions);
+    }
+}


### PR DESCRIPTION
Ticket: https://github.com/mpiechot/PokemonSoulLinkDiscord/issues/41

## Summary
- Add a diff-based slash command registration service that compares local command snapshots with Discord's remote definitions.
- Skip global or guild bulk overwrites when definitions are unchanged.
- Add `DISCORD_COMMAND_REGISTRATION_MODE` and `DISCORD_COMMAND_GUILD_IDS` support for global, guild, and development registration flows.
- Log registration failures per target and continue with the remaining startup work.
- Add service tests for unchanged, changed, and failed registration paths.

Closes #41

## Verification
- `dotnet build PokeSoulLinkBot\PokeSoulLinkBot.csproj --no-restore --verbosity minimal`
- `dotnet test PokeSoulLinkBot.Tests\PokeSoulLinkBot.Tests.csproj --no-restore --verbosity minimal`