### PR TITLE
Render status output as unified embeds

### DIFF
--- a/PokeSoulLinkBot.Tests/EmbedFactoryStatusTests.cs
+++ b/PokeSoulLinkBot.Tests/EmbedFactoryStatusTests.cs
@@ -154,19 +154,106 @@ public sealed class EmbedFactoryStatusTests
         }
     }
 
+    [Fact]
+    public void CreateStatusEmbedBatches_ShouldKeepTypicalStatusInOneDiscordMessage()
+    {
+        var run = CreateRunWithPlayers("marpie1", "beneerdbeermarmelade", "darkstyle4957");
+        for (var routeIndex = 1; routeIndex <= 18; routeIndex++)
+        {
+            var linkGroup = CreateLinkGroup($"route-{routeIndex:000}", routeIndex <= 12, $"Pokemon-{routeIndex:000}");
+            foreach (var player in run.Players.Skip(1))
+            {
+                linkGroup.Entries.Add(new LinkedPokemon
+                {
+                    PlayerUserId = player.UserId,
+                    PlayerName = player.UserName,
+                    PokemonName = $"Pokemon-{player.UserId}-{routeIndex:000}",
+                    IsAlive = routeIndex <= 12,
+                });
+            }
+
+            run.LinkGroups.Add(linkGroup);
+            if (routeIndex <= 6)
+            {
+                run.ActiveLinks[routeIndex - 1] = linkGroup;
+            }
+        }
+
+        var embedFactory = new EmbedFactory();
+
+        var batches = embedFactory.CreateStatusEmbedBatches(run, "attachment://status.png");
+
+        var batch = Assert.Single(batches);
+        Assert.InRange(batch.Count, 1, 10);
+        Assert.Contains(batch, embed => embed.Title == "Run Status");
+        Assert.Contains(batch, embed => embed.Description?.Contains("**Current Team**", StringComparison.Ordinal) == true);
+        Assert.Contains(batch, embed => embed.Description?.Contains("**Box**", StringComparison.Ordinal) == true);
+        Assert.Contains(batch, embed => embed.Description?.Contains("**Dead**", StringComparison.Ordinal) == true);
+    }
+
+    [Fact]
+    public void CreateStatusEmbedBatches_ShouldRespectDiscordEmbedBatchLimits()
+    {
+        var run = CreateRun();
+        for (var routeIndex = 1; routeIndex <= 180; routeIndex++)
+        {
+            run.LinkGroups.Add(CreateLinkGroup($"route-{routeIndex:000}", true, $"Pokemon-{routeIndex:000}"));
+        }
+
+        var embedFactory = new EmbedFactory();
+
+        var batches = embedFactory.CreateStatusEmbedBatches(run, "attachment://status.png");
+        var fullDescriptions = string.Join(
+            Environment.NewLine,
+            batches.SelectMany(batch => batch).Select(embed => embed.Description));
+
+        Assert.All(batches, batch => Assert.InRange(batch.Count, 1, 10));
+        Assert.All(batches, batch => Assert.InRange(GetEmbedBatchLength(batch), 1, 6000));
+        for (var routeIndex = 1; routeIndex <= 180; routeIndex++)
+        {
+            Assert.Contains($"route-{routeIndex:000}", fullDescriptions, StringComparison.Ordinal);
+        }
+    }
+
     private static SoulLinkRun CreateRun()
     {
-        return new SoulLinkRun
+        return CreateRunWithPlayers("marpie1");
+    }
+
+    private static SoulLinkRun CreateRunWithPlayers(params string[] playerNames)
+    {
+        var run = new SoulLinkRun
         {
             GuildId = "guild-1",
             Name = "Ruby",
             Game = "ruby",
             StartedAtUtc = DateTime.UtcNow,
-            Players = new List<RunPlayer>
-            {
-                new RunPlayer { UserId = 1, UserName = "marpie1" },
-            },
         };
+
+        for (var playerIndex = 0; playerIndex < playerNames.Length; playerIndex++)
+        {
+            run.Players.Add(new RunPlayer
+            {
+                UserId = (ulong)(playerIndex + 1),
+                UserName = playerNames[playerIndex],
+            });
+        }
+
+        return run;
+    }
+
+    private static int GetEmbedBatchLength(IReadOnlyCollection<Discord.Embed> embeds)
+    {
+        return embeds.Sum(embed =>
+            (embed.Title?.Length ?? 0)
+            + (embed.Description?.Length ?? 0)
+            + embed.Fields.Sum(GetEmbedFieldLength));
+    }
+
+    private static int GetEmbedFieldLength(Discord.EmbedField field)
+    {
+        var fieldValue = Convert.ToString(field.Value);
+        return field.Name.Length + (fieldValue?.Length ?? 0);
     }
 
     private static LinkGroup CreateLinkGroup(string route, bool isAlive, string pokemonName)

--- a/PokeSoulLinkBot.Tests/SlashCommandResponsePatternTests.cs
+++ b/PokeSoulLinkBot.Tests/SlashCommandResponsePatternTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace PokeSoulLinkBot.Tests;
@@ -75,6 +76,18 @@ public sealed class SlashCommandResponsePatternTests
     }
 
     [Fact]
+    public void StatusCommand_ShouldUseEmbedBatchesForVisualContinuity()
+    {
+        var source = ReadSourceFile("PokeSoulLinkBot", "Bot", "Commands", "StatusCommand.cs");
+        var handleAsyncBody = ExtractMethodBody(source, "public async Task HandleAsync(SocketSlashCommand command, ISlashCommandResponse response)");
+
+        Assert.Contains("this.embedFactory.CreateStatusEmbedBatches(activeRun, image.AttachmentUrl)", handleAsyncBody, StringComparison.Ordinal);
+        Assert.Contains("response.SendFilesAsync(new[] { image.FileAttachment }, embeds: firstEmbedBatch)", handleAsyncBody, StringComparison.Ordinal);
+        Assert.Contains("response.SendEmbedsAsync(embedBatch)", handleAsyncBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("response.SendFollowupsAsync", handleAsyncBody, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Router_ShouldGuardErrorResponseFailures()
     {
         var routerSource = ReadSourceFile("PokeSoulLinkBot", "Bot", "SlashCommandRouter.cs");
@@ -101,10 +114,31 @@ public sealed class SlashCommandResponsePatternTests
         return File.ReadAllText(Path.Combine(new[] { GetRepositoryRoot() }.Concat(pathParts).ToArray()));
     }
 
-    private static string GetRepositoryRoot()
+    private static string GetRepositoryRoot([CallerFilePath] string sourceFilePath = "")
     {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        var sourceFileRoot = FindRepositoryRoot(new FileInfo(sourceFilePath).Directory);
+        if (sourceFileRoot is not null)
+        {
+            return sourceFileRoot;
+        }
 
+        var workingDirectoryRoot = FindRepositoryRoot(new DirectoryInfo(Directory.GetCurrentDirectory()));
+        if (workingDirectoryRoot is not null)
+        {
+            return workingDirectoryRoot;
+        }
+
+        var baseDirectoryRoot = FindRepositoryRoot(new DirectoryInfo(AppContext.BaseDirectory));
+        if (baseDirectoryRoot is not null)
+        {
+            return baseDirectoryRoot;
+        }
+
+        throw new DirectoryNotFoundException("Could not find the repository root.");
+    }
+
+    private static string? FindRepositoryRoot(DirectoryInfo? directory)
+    {
         while (directory is not null)
         {
             if (Directory.Exists(Path.Combine(directory.FullName, "PokeSoulLinkBot"))
@@ -116,7 +150,7 @@ public sealed class SlashCommandResponsePatternTests
             directory = directory.Parent;
         }
 
-        throw new DirectoryNotFoundException("Could not find the repository root.");
+        return null;
     }
 
     private static string ExtractMethodBody(string source, string signature)

--- a/PokeSoulLinkBot/Bot/Commands/StatusCommand.cs
+++ b/PokeSoulLinkBot/Bot/Commands/StatusCommand.cs
@@ -65,12 +65,15 @@ public class StatusCommand : ISlashCommand
         var activeRun = this.runService.GetActiveRun(guildId);
         await this.EnrichMissingPokemonTypesAsync(activeRun);
 
-        var messages = this.embedFactory.CreateStatusMessages(activeRun);
         var image = this.embedImageFactory.CreateStatusImage();
-        var embed = this.embedFactory.CreateRunSummaryEmbed("Run Status", activeRun, image.AttachmentUrl);
-        await response.SendFileAsync(image.FileAttachment, text: messages[0], embed: embed);
+        var embedBatches = this.embedFactory.CreateStatusEmbedBatches(activeRun, image.AttachmentUrl);
+        var firstEmbedBatch = embedBatches.First();
+        await response.SendFilesAsync(new[] { image.FileAttachment }, embeds: firstEmbedBatch);
 
-        await response.SendFollowupsAsync(messages.Skip(1));
+        foreach (var embedBatch in embedBatches.Skip(1))
+        {
+            await response.SendEmbedsAsync(embedBatch);
+        }
     }
 
     private async Task EnrichMissingPokemonTypesAsync(SoulLinkRun run)

--- a/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
+++ b/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using Discord;
 using PokeSoulLinkBot.Bot.Helpers;
@@ -11,6 +12,8 @@ namespace PokeSoulLinkBot.Bot.Factories;
 public sealed class EmbedFactory
 {
     private const int DiscordMessageMaxLength = 2000;
+    private const int DiscordEmbedsPerMessageMaxCount = 10;
+    private const int DiscordEmbedsPerMessageMaxCharacters = 6000;
 
     /// <summary>
     /// Creates an embed for a newly started run.
@@ -279,6 +282,27 @@ public sealed class EmbedFactory
     }
 
     /// <summary>
+    /// Creates Discord-compatible status embed batches for the active run.
+    /// </summary>
+    /// <param name="run">The active run.</param>
+    /// <param name="thumbnailUrl">The attachment URL of the thumbnail shown in the first embed.</param>
+    /// <returns>The paged status embed batches.</returns>
+    public IReadOnlyList<IReadOnlyList<Embed>> CreateStatusEmbedBatches(SoulLinkRun run, string thumbnailUrl)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        ArgumentException.ThrowIfNullOrWhiteSpace(thumbnailUrl);
+
+        var embeds = new List<Embed>
+        {
+            this.CreateRunSummaryEmbed("Run Status", run, thumbnailUrl),
+        };
+
+        embeds.AddRange(this.CreateStatusBlocks(run).Select(CreateStatusBlockEmbed));
+
+        return BatchEmbeds(embeds);
+    }
+
+    /// <summary>
     /// Creates the message for a newly selected active team.
     /// </summary>
     /// <param name="run">The active run.</param>
@@ -458,6 +482,57 @@ public sealed class EmbedFactory
         }
 
         return messages;
+    }
+
+    private static IReadOnlyList<IReadOnlyList<Embed>> BatchEmbeds(IReadOnlyList<Embed> embeds)
+    {
+        var batches = new List<IReadOnlyList<Embed>>();
+        var currentBatch = new List<Embed>();
+        var currentBatchLength = 0;
+
+        foreach (var embed in embeds)
+        {
+            var embedLength = EstimateEmbedLength(embed);
+            if (currentBatch.Count > 0
+                && (currentBatch.Count >= DiscordEmbedsPerMessageMaxCount
+                    || currentBatchLength + embedLength > DiscordEmbedsPerMessageMaxCharacters))
+            {
+                batches.Add(currentBatch);
+                currentBatch = new List<Embed>();
+                currentBatchLength = 0;
+            }
+
+            currentBatch.Add(embed);
+            currentBatchLength += embedLength;
+        }
+
+        if (currentBatch.Count > 0)
+        {
+            batches.Add(currentBatch);
+        }
+
+        return batches;
+    }
+
+    private static Embed CreateStatusBlockEmbed(string block)
+    {
+        return new EmbedBuilder()
+            .WithColor(Color.Blue)
+            .WithDescription(block)
+            .Build();
+    }
+
+    private static int EstimateEmbedLength(Embed embed)
+    {
+        var fieldsLength = embed.Fields.Sum(field =>
+        {
+            var fieldValue = Convert.ToString(field.Value, CultureInfo.InvariantCulture);
+            return field.Name.Length + (fieldValue?.Length ?? 0);
+        });
+
+        return (embed.Title?.Length ?? 0)
+            + (embed.Description?.Length ?? 0)
+            + fieldsLength;
     }
 
     private static string JoinBlocks(IReadOnlyList<string> blocks)

--- a/PokeSoulLinkBot/Bot/Helpers/DiscordSlashCommandResponse.cs
+++ b/PokeSoulLinkBot/Bot/Helpers/DiscordSlashCommandResponse.cs
@@ -41,6 +41,17 @@ public sealed class DiscordSlashCommandResponse : ISlashCommandResponse
     }
 
     /// <inheritdoc />
+    public Task SendEmbedsAsync(IReadOnlyList<Embed> embeds, bool ephemeral = false)
+    {
+        ArgumentNullException.ThrowIfNull(embeds);
+
+        var embedArray = embeds.ToArray();
+        return this.command.HasResponded
+            ? this.command.FollowupAsync(embeds: embedArray, ephemeral: ephemeral)
+            : this.command.RespondAsync(embeds: embedArray, ephemeral: ephemeral);
+    }
+
+    /// <inheritdoc />
     public Task SendFileAsync(
         FileAttachment fileAttachment,
         string? text = null,
@@ -50,6 +61,22 @@ public sealed class DiscordSlashCommandResponse : ISlashCommandResponse
         return this.command.HasResponded
             ? this.command.FollowupWithFileAsync(fileAttachment, text: text, embed: embed, ephemeral: ephemeral)
             : this.command.RespondWithFileAsync(fileAttachment, text: text, embed: embed, ephemeral: ephemeral);
+    }
+
+    /// <inheritdoc />
+    public Task SendFilesAsync(
+        IEnumerable<FileAttachment> fileAttachments,
+        string? text = null,
+        IReadOnlyList<Embed>? embeds = null,
+        bool ephemeral = false)
+    {
+        ArgumentNullException.ThrowIfNull(fileAttachments);
+
+        var fileAttachmentList = fileAttachments.ToList();
+        var embedArray = embeds?.ToArray() ?? Array.Empty<Embed>();
+        return this.command.HasResponded
+            ? this.command.FollowupWithFilesAsync(fileAttachmentList, text: text, embeds: embedArray, ephemeral: ephemeral)
+            : this.command.RespondWithFilesAsync(fileAttachmentList, text: text, embeds: embedArray, ephemeral: ephemeral);
     }
 
     /// <inheritdoc />

--- a/PokeSoulLinkBot/Bot/Helpers/ISlashCommandResponse.cs
+++ b/PokeSoulLinkBot/Bot/Helpers/ISlashCommandResponse.cs
@@ -33,6 +33,14 @@ public interface ISlashCommandResponse
     Task SendAsync(string? text = null, Embed? embed = null, bool ephemeral = false);
 
     /// <summary>
+    /// Sends an embed response.
+    /// </summary>
+    /// <param name="embeds">The embeds to send in one Discord message.</param>
+    /// <param name="ephemeral">A value indicating whether the response should be visible only to the caller.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task SendEmbedsAsync(IReadOnlyList<Embed> embeds, bool ephemeral = false);
+
+    /// <summary>
     /// Sends a file response.
     /// </summary>
     /// <param name="fileAttachment">The file attachment.</param>
@@ -41,6 +49,20 @@ public interface ISlashCommandResponse
     /// <param name="ephemeral">A value indicating whether the response should be visible only to the caller.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     Task SendFileAsync(FileAttachment fileAttachment, string? text = null, Embed? embed = null, bool ephemeral = false);
+
+    /// <summary>
+    /// Sends a file response with multiple embeds.
+    /// </summary>
+    /// <param name="fileAttachments">The file attachments.</param>
+    /// <param name="text">The response text.</param>
+    /// <param name="embeds">The embeds to send in one Discord message.</param>
+    /// <param name="ephemeral">A value indicating whether the response should be visible only to the caller.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task SendFilesAsync(
+        IEnumerable<FileAttachment> fileAttachments,
+        string? text = null,
+        IReadOnlyList<Embed>? embeds = null,
+        bool ephemeral = false);
 
     /// <summary>
     /// Sends supplemental followup messages.


### PR DESCRIPTION
Ticket: https://github.com/mpiechot/PokemonSoulLinkDiscord/issues/50

## Summary

- Renders `/status` as grouped embed batches instead of regular text followups so normal-sized status output appears as one cohesive Discord bot message.
- Extends the slash-command response adapter to send multiple embeds and file responses with multiple embeds.
- Keeps Discord embed limits by batching status embeds when a run becomes too large for one message.
- Hardens source-pattern tests so they also work from isolated build output directories.

## Verification

- `dotnet format PokeSoulLinkBot\PokeSoulLinkBot.slnx --no-restore`
- `dotnet build PokeSoulLinkBot.Tests\PokeSoulLinkBot.Tests.csproj -p:OutDir=%TEMP%\pokemon-soul-link-status-outdir\ -v:minimal`
- `dotnet vstest %TEMP%\pokemon-soul-link-status-outdir\PokeSoulLinkBot.Tests.dll`
- `git diff --check`
- `git ls-files --eol` for staged text files

Note: The normal `dotnet test PokeSoulLinkBot\PokeSoulLinkBot.slnx --no-restore` path could not overwrite the local `bin\Debug` app because the bot and Visual Studio are currently running. The isolated temp build/test path was used instead.

Closes #50.