### PR TITLE
Add health diagnostics command

### DIFF
--- a/PokeSoulLinkBot.Tests/BotDiagnosticsServiceTests.cs
+++ b/PokeSoulLinkBot.Tests/BotDiagnosticsServiceTests.cs
@@ -1,0 +1,49 @@
+using PokeSoulLinkBot.Application.Services;
+using PokeSoulLinkBot.Core.Models;
+using Xunit;
+
+namespace PokeSoulLinkBot.Tests;
+
+public sealed class BotDiagnosticsServiceTests
+{
+    [Fact]
+    public void GetRecentEvents_ShouldReturnNewestEventsWithinCapacity()
+    {
+        var service = new BotDiagnosticsService(capacity: 2);
+
+        service.Record(new DiagnosticEvent { Severity = "Warning", Source = "test", Message = "first" });
+        service.Record(new DiagnosticEvent { Severity = "Error", Source = "test", Message = "second" });
+        service.Record(new DiagnosticEvent { Severity = "Warning", Source = "test", Message = "third" });
+
+        var events = service.GetRecentEvents(10);
+
+        Assert.Equal(2, events.Count);
+        Assert.Equal("third", events[0].Message);
+        Assert.Equal("second", events[1].Message);
+    }
+
+    [Fact]
+    public void RecordException_ShouldStoreCommandContextAndExceptionType()
+    {
+        var service = new BotDiagnosticsService();
+
+        service.RecordException(
+            "Error",
+            "SlashCommandRouter",
+            "Slash command failed.",
+            new InvalidOperationException("No active run."),
+            "status",
+            "none",
+            42);
+
+        var diagnosticEvent = Assert.Single(service.GetRecentEvents(5));
+
+        Assert.Equal("Error", diagnosticEvent.Severity);
+        Assert.Equal("SlashCommandRouter", diagnosticEvent.Source);
+        Assert.Equal("status", diagnosticEvent.CommandName);
+        Assert.Equal("none", diagnosticEvent.Parameters);
+        Assert.Equal("InvalidOperationException", diagnosticEvent.ExceptionType);
+        Assert.Equal("No active run.", diagnosticEvent.ExceptionMessage);
+        Assert.Equal(42, diagnosticEvent.ElapsedMilliseconds);
+    }
+}

--- a/PokeSoulLinkBot.Tests/CommandDefinitionTests.cs
+++ b/PokeSoulLinkBot.Tests/CommandDefinitionTests.cs
@@ -18,6 +18,7 @@ public sealed class CommandDefinitionTests
             { new CatchCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory(), new StubPokemonLookupService(), new StubGameDataCatalogService()), "catch", new[] { "route", "player", "pokemon" } },
             { new CatchCheckCommand(new StubCatchEligibilityService(), new EmbedFactory()), "catch-check", new[] { "pokemon" } },
             { new DeathCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory()), "death", new[] { "route", "reason", "player" } },
+            { new HealthCommand(new StubBotHealthService(), new EmbedFactory()), "health", Array.Empty<string>() },
             { new PokedexCommand(new StubPokedexService(), new PokedexPresenter()), "pokedex", new[] { "name" } },
             { new RouteDeathCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory(), new StubGameDataCatalogService()), "route-death", new[] { "route", "reason", "player" } },
             { new RunEndCommand(new StubRunService(), new EmbedFactory(), CreateImageFactory()), "run-end", new[] { "reason" } },
@@ -215,6 +216,14 @@ public sealed class CommandDefinitionTests
         }
     }
 
+    private sealed class StubBotHealthService : IBotHealthService
+    {
+        public Task<BotHealthReport> GetReportAsync(string guildId)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
     private sealed class StubArenaInfoService : IArenaInfoService
     {
         public Task<ArenaInfo> GetArenaInfoAsync(string edition, int arenaNumber)
@@ -225,6 +234,11 @@ public sealed class CommandDefinitionTests
 
     private sealed class StubGameDataCatalogService : IGameDataCatalogService
     {
+        public GameDataCatalogStatus GetStatus()
+        {
+            return new GameDataCatalogStatus();
+        }
+
         public Task InitializeAsync()
         {
             return Task.CompletedTask;

--- a/PokeSoulLinkBot.Tests/EmbedFactoryHealthTests.cs
+++ b/PokeSoulLinkBot.Tests/EmbedFactoryHealthTests.cs
@@ -1,0 +1,69 @@
+using PokeSoulLinkBot.Bot.Factories;
+using PokeSoulLinkBot.Core.Models;
+using Xunit;
+
+namespace PokeSoulLinkBot.Tests;
+
+public sealed class EmbedFactoryHealthTests
+{
+    [Fact]
+    public void CreateHealthEmbed_ShouldIncludeShareableDiagnosticSummary()
+    {
+        var report = new BotHealthReport
+        {
+            DiscordConnectionState = "Connected",
+            DiscordLatencyMilliseconds = 23,
+            GuildCount = 1,
+            ActiveRun = new ActiveRunHealthStatus
+            {
+                Name = "Run 4",
+                Game = "Rubin",
+                PlayerCount = 3,
+                LinkGroupCount = 12,
+                ActiveTeamCount = 6,
+                DeadGroupCount = 2,
+                LostRouteCount = 1,
+            },
+            GameDataCatalog = new GameDataCatalogStatus
+            {
+                IsReady = true,
+                Source = "cache",
+                EditionCount = 42,
+                RouteCount = 900,
+            },
+            PokemonDataCache = new PokemonDataCacheStatus
+            {
+                IsLoaded = true,
+                Version = 1,
+                NameIndexCount = 1000,
+                PokemonInfoCount = 25,
+                PokedexEntryCount = 8,
+            },
+            RecentEvents = new[]
+            {
+                new DiagnosticEvent
+                {
+                    OccurredAtUtc = new DateTimeOffset(2026, 6, 29, 18, 0, 0, TimeSpan.Zero),
+                    Severity = "Error",
+                    Source = "SlashCommandRouter",
+                    Message = "Slash command failed.",
+                    CommandName = "status",
+                    Parameters = "none",
+                    ExceptionType = "InvalidOperationException",
+                    ExceptionMessage = "No active run.",
+                    ElapsedMilliseconds = 17,
+                },
+            },
+        };
+        var embedFactory = new EmbedFactory();
+
+        var embed = embedFactory.CreateHealthEmbed(report);
+
+        Assert.Equal("Bot Diagnostics", embed.Title);
+        Assert.Contains(embed.Fields, field => field.Name == "Discord" && field.Value.Contains("Connected", StringComparison.Ordinal));
+        Assert.Contains(embed.Fields, field => field.Name == "Active Run" && field.Value.Contains("Run 4", StringComparison.Ordinal));
+        Assert.Contains(embed.Fields, field => field.Name == "Data" && field.Value.Contains("Names/info/dex: 1000/25/8", StringComparison.Ordinal));
+        Assert.Contains(embed.Fields, field => field.Name == "Recent Diagnostics" && field.Value.Contains("/status", StringComparison.Ordinal));
+        Assert.Contains(embed.Fields, field => field.Name == "Recent Diagnostics" && field.Value.Contains("No active run.", StringComparison.Ordinal));
+    }
+}

--- a/PokeSoulLinkBot/Application/Interfaces/IBotDiagnosticsService.cs
+++ b/PokeSoulLinkBot/Application/Interfaces/IBotDiagnosticsService.cs
@@ -1,0 +1,41 @@
+using PokeSoulLinkBot.Core.Models;
+
+namespace PokeSoulLinkBot.Application.Interfaces;
+
+/// <summary>
+/// Stores recent diagnostic events that can be reported after an error occurred.
+/// </summary>
+public interface IBotDiagnosticsService
+{
+    /// <summary>
+    /// Records a diagnostic event.
+    /// </summary>
+    /// <param name="diagnosticEvent">The event to record.</param>
+    void Record(DiagnosticEvent diagnosticEvent);
+
+    /// <summary>
+    /// Records an exception as a diagnostic event.
+    /// </summary>
+    /// <param name="severity">The event severity.</param>
+    /// <param name="source">The component that observed the event.</param>
+    /// <param name="message">The short event message.</param>
+    /// <param name="exception">The observed exception.</param>
+    /// <param name="commandName">The related command name, if any.</param>
+    /// <param name="parameters">The related command parameters, if any.</param>
+    /// <param name="elapsedMilliseconds">The elapsed duration in milliseconds, if any.</param>
+    void RecordException(
+        string severity,
+        string source,
+        string message,
+        Exception exception,
+        string? commandName = null,
+        string? parameters = null,
+        long? elapsedMilliseconds = null);
+
+    /// <summary>
+    /// Gets the most recent diagnostic events, newest first.
+    /// </summary>
+    /// <param name="maxCount">The maximum number of events to return.</param>
+    /// <returns>The recent diagnostic events.</returns>
+    IReadOnlyList<DiagnosticEvent> GetRecentEvents(int maxCount);
+}

--- a/PokeSoulLinkBot/Application/Interfaces/IBotHealthService.cs
+++ b/PokeSoulLinkBot/Application/Interfaces/IBotHealthService.cs
@@ -1,0 +1,16 @@
+using PokeSoulLinkBot.Core.Models;
+
+namespace PokeSoulLinkBot.Application.Interfaces;
+
+/// <summary>
+/// Creates shareable bot diagnostic reports.
+/// </summary>
+public interface IBotHealthService
+{
+    /// <summary>
+    /// Creates a health report for the specified guild context.
+    /// </summary>
+    /// <param name="guildId">The Discord guild identifier.</param>
+    /// <returns>The health report.</returns>
+    Task<BotHealthReport> GetReportAsync(string guildId);
+}

--- a/PokeSoulLinkBot/Application/Interfaces/IGameDataCatalogService.cs
+++ b/PokeSoulLinkBot/Application/Interfaces/IGameDataCatalogService.cs
@@ -14,6 +14,12 @@ public interface IGameDataCatalogService
     Task InitializeAsync();
 
     /// <summary>
+    /// Gets the current catalog status without exposing local file paths.
+    /// </summary>
+    /// <returns>The current catalog status.</returns>
+    GameDataCatalogStatus GetStatus();
+
+    /// <summary>
     /// Gets all known game editions.
     /// </summary>
     /// <returns>A read-only collection of game editions.</returns>

--- a/PokeSoulLinkBot/Application/Services/BotDiagnosticsService.cs
+++ b/PokeSoulLinkBot/Application/Services/BotDiagnosticsService.cs
@@ -1,0 +1,119 @@
+using PokeSoulLinkBot.Application.Interfaces;
+using PokeSoulLinkBot.Core.Models;
+
+namespace PokeSoulLinkBot.Application.Services;
+
+/// <summary>
+/// Keeps a bounded in-memory list of recent diagnostic events.
+/// </summary>
+public sealed class BotDiagnosticsService : IBotDiagnosticsService
+{
+    private const int DefaultCapacity = 50;
+
+    private readonly object syncRoot = new object();
+    private readonly int capacity;
+    private readonly Queue<DiagnosticEvent> events = new Queue<DiagnosticEvent>();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BotDiagnosticsService"/> class.
+    /// </summary>
+    /// <param name="capacity">The maximum number of events retained in memory.</param>
+    public BotDiagnosticsService(int capacity = DefaultCapacity)
+    {
+        if (capacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be greater than zero.");
+        }
+
+        this.capacity = capacity;
+    }
+
+    /// <inheritdoc />
+    public void Record(DiagnosticEvent diagnosticEvent)
+    {
+        ArgumentNullException.ThrowIfNull(diagnosticEvent);
+
+        lock (this.syncRoot)
+        {
+            this.events.Enqueue(diagnosticEvent);
+            while (this.events.Count > this.capacity)
+            {
+                this.events.Dequeue();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void RecordException(
+        string severity,
+        string source,
+        string message,
+        Exception exception,
+        string? commandName = null,
+        string? parameters = null,
+        long? elapsedMilliseconds = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(severity);
+        ArgumentException.ThrowIfNullOrWhiteSpace(source);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+        ArgumentNullException.ThrowIfNull(exception);
+
+        this.Record(new DiagnosticEvent
+        {
+            OccurredAtUtc = DateTimeOffset.UtcNow,
+            Severity = severity.Trim(),
+            Source = source.Trim(),
+            Message = message.Trim(),
+            CommandName = string.IsNullOrWhiteSpace(commandName) ? null : commandName.Trim(),
+            Parameters = string.IsNullOrWhiteSpace(parameters) ? null : parameters.Trim(),
+            ExceptionType = exception.GetType().Name,
+            ExceptionMessage = GetSafeExceptionMessage(exception),
+            ElapsedMilliseconds = elapsedMilliseconds,
+        });
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<DiagnosticEvent> GetRecentEvents(int maxCount)
+    {
+        if (maxCount <= 0)
+        {
+            return Array.Empty<DiagnosticEvent>();
+        }
+
+        lock (this.syncRoot)
+        {
+            return this.events
+                .Reverse()
+                .Take(maxCount)
+                .Select(CloneEvent)
+                .ToList();
+        }
+    }
+
+    private static DiagnosticEvent CloneEvent(DiagnosticEvent diagnosticEvent)
+    {
+        return new DiagnosticEvent
+        {
+            OccurredAtUtc = diagnosticEvent.OccurredAtUtc,
+            Severity = diagnosticEvent.Severity,
+            Source = diagnosticEvent.Source,
+            Message = diagnosticEvent.Message,
+            CommandName = diagnosticEvent.CommandName,
+            Parameters = diagnosticEvent.Parameters,
+            ExceptionType = diagnosticEvent.ExceptionType,
+            ExceptionMessage = diagnosticEvent.ExceptionMessage,
+            ElapsedMilliseconds = diagnosticEvent.ElapsedMilliseconds,
+        };
+    }
+
+    private static string? GetSafeExceptionMessage(Exception exception)
+    {
+        var message = string.IsNullOrWhiteSpace(exception.Message)
+            ? exception.InnerException?.Message
+            : exception.Message;
+
+        return string.IsNullOrWhiteSpace(message)
+            ? null
+            : message.Trim();
+    }
+}

--- a/PokeSoulLinkBot/Application/Services/PokeApiGameDataCatalogService.cs
+++ b/PokeSoulLinkBot/Application/Services/PokeApiGameDataCatalogService.cs
@@ -24,6 +24,7 @@ public sealed class PokeApiGameDataCatalogService : IGameDataCatalogService
     private readonly HttpClient httpClient;
     private readonly SemaphoreSlim initializationLock = new SemaphoreSlim(1, 1);
     private GameDataCatalog? catalog;
+    private string catalogSource = "none";
     private Task? refreshTask;
 
     /// <summary>
@@ -64,6 +65,7 @@ public sealed class PokeApiGameDataCatalogService : IGameDataCatalogService
                     "Using game data catalog source cache with {EditionCount} editions and {RouteCount} routes.",
                     this.catalog.Editions.Count,
                     this.catalog.Editions.Sum(edition => edition.Routes.Count));
+                this.catalogSource = "cache";
                 this.StartRefreshInBackground();
                 return;
             }
@@ -75,6 +77,7 @@ public sealed class PokeApiGameDataCatalogService : IGameDataCatalogService
                     "Using game data catalog source fallback with {EditionCount} editions and {RouteCount} routes.",
                     this.catalog.Editions.Count,
                     this.catalog.Editions.Sum(edition => edition.Routes.Count));
+                this.catalogSource = "fallback";
                 this.StartRefreshInBackground();
                 return;
             }
@@ -87,6 +90,22 @@ public sealed class PokeApiGameDataCatalogService : IGameDataCatalogService
         {
             this.initializationLock.Release();
         }
+    }
+
+    /// <inheritdoc />
+    public GameDataCatalogStatus GetStatus()
+    {
+        var currentCatalog = this.catalog;
+        return new GameDataCatalogStatus
+        {
+            IsReady = currentCatalog is not null,
+            Source = currentCatalog is null ? "none" : this.catalogSource,
+            IsRefreshRunning = this.refreshTask is not null,
+            SchemaVersion = currentCatalog?.SchemaVersion,
+            RefreshedAtUtc = currentCatalog?.RefreshedAtUtc,
+            EditionCount = currentCatalog?.Editions.Count ?? 0,
+            RouteCount = currentCatalog?.Editions.Sum(edition => edition.Routes.Count) ?? 0,
+        };
     }
 
     /// <inheritdoc />
@@ -382,6 +401,7 @@ public sealed class PokeApiGameDataCatalogService : IGameDataCatalogService
         {
             var refreshedCatalog = await this.RefreshCatalogAsync();
             this.catalog = refreshedCatalog;
+            this.catalogSource = "PokeAPI";
 
             try
             {

--- a/PokeSoulLinkBot/Application/Services/PokemonDataCacheStore.cs
+++ b/PokeSoulLinkBot/Application/Services/PokemonDataCacheStore.cs
@@ -39,6 +39,32 @@ public sealed class PokemonDataCacheStore
     }
 
     /// <summary>
+    /// Gets a shareable status summary for the cache.
+    /// </summary>
+    /// <returns>The cache status.</returns>
+    public async Task<PokemonDataCacheStatus> GetStatusAsync()
+    {
+        _ = await this.GetCacheAsync();
+        await this.cacheLock.WaitAsync();
+        try
+        {
+            return new PokemonDataCacheStatus
+            {
+                IsLoaded = this.cache is not null,
+                Version = this.cache!.Version,
+                RefreshedAtUtc = this.cache.RefreshedAtUtc,
+                NameIndexCount = this.cache.NameIndex.Count,
+                PokemonInfoCount = this.cache.PokemonInfos.Count,
+                PokedexEntryCount = this.cache.PokedexEntries.Count,
+            };
+        }
+        finally
+        {
+            this.cacheLock.Release();
+        }
+    }
+
+    /// <summary>
     /// Gets the cached localized name index.
     /// </summary>
     /// <returns>The cached index, or <see langword="null"/> when no index exists.</returns>

--- a/PokeSoulLinkBot/Bot/Commands/HealthCommand.cs
+++ b/PokeSoulLinkBot/Bot/Commands/HealthCommand.cs
@@ -1,0 +1,54 @@
+using Discord;
+using Discord.WebSocket;
+using PokeSoulLinkBot.Application.Interfaces;
+using PokeSoulLinkBot.Bot.Factories;
+using PokeSoulLinkBot.Bot.Helpers;
+
+namespace PokeSoulLinkBot.Bot.Commands;
+
+/// <summary>
+/// Handles the "health" slash command.
+/// </summary>
+public sealed class HealthCommand : ISlashCommand
+{
+    private readonly IBotHealthService healthService;
+    private readonly EmbedFactory embedFactory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HealthCommand"/> class.
+    /// </summary>
+    /// <param name="healthService">The health service.</param>
+    /// <param name="embedFactory">The embed factory.</param>
+    public HealthCommand(
+        IBotHealthService healthService,
+        EmbedFactory embedFactory)
+    {
+        this.healthService = healthService ?? throw new ArgumentNullException(nameof(healthService));
+        this.embedFactory = embedFactory ?? throw new ArgumentNullException(nameof(embedFactory));
+    }
+
+    /// <inheritdoc />
+    public string CommandName => "health";
+
+    /// <inheritdoc />
+    public ApplicationCommandProperties BuildDefinition()
+    {
+        return new SlashCommandBuilder()
+            .WithName(this.CommandName)
+            .WithDescription("Show bot health and recent diagnostics.")
+            .Build();
+    }
+
+    /// <inheritdoc />
+    public async Task HandleAsync(SocketSlashCommand command, ISlashCommandResponse response)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(response);
+
+        var guildId = CommandOptionHelper.GetGuildId(command);
+        var report = await this.healthService.GetReportAsync(guildId);
+        var embed = this.embedFactory.CreateHealthEmbed(report);
+
+        await response.SendAsync(embed: embed);
+    }
+}

--- a/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
+++ b/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
@@ -434,6 +434,26 @@ public sealed class EmbedFactory
     }
 
     /// <summary>
+    /// Creates an embed for bot diagnostics.
+    /// </summary>
+    /// <param name="report">The health report.</param>
+    /// <returns>The created embed.</returns>
+    public Embed CreateHealthEmbed(BotHealthReport report)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        return new EmbedBuilder()
+            .WithTitle("Bot Diagnostics")
+            .WithColor(GetHealthColor(report))
+            .AddField("Discord", CreateDiscordHealthSummary(report), true)
+            .AddField("Active Run", CreateActiveRunHealthSummary(report.ActiveRun), true)
+            .AddField("Data", CreateDataHealthSummary(report), true)
+            .AddField("Recent Diagnostics", CreateRecentDiagnosticsSummary(report.RecentEvents))
+            .AddField("Report", $"Created: {report.CreatedAtUtc:yyyy-MM-dd HH:mm:ss} UTC")
+            .Build();
+    }
+
+    /// <summary>
     /// Creates an error embed.
     /// </summary>
     /// <param name="message">The error message.</param>
@@ -640,6 +660,109 @@ public sealed class EmbedFactory
         }
 
         return string.Concat(value.AsSpan(0, maxFieldLength - 3), "...");
+    }
+
+    private static Color GetHealthColor(BotHealthReport report)
+    {
+        if (report.RecentEvents.Any(diagnosticEvent =>
+            string.Equals(diagnosticEvent.Severity, "Error", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(diagnosticEvent.Severity, "Fatal", StringComparison.OrdinalIgnoreCase)))
+        {
+            return Color.Red;
+        }
+
+        if (!string.Equals(report.DiscordConnectionState, "Connected", StringComparison.OrdinalIgnoreCase) ||
+            !report.GameDataCatalog.IsReady)
+        {
+            return Color.Orange;
+        }
+
+        return Color.Green;
+    }
+
+    private static string CreateDiscordHealthSummary(BotHealthReport report)
+    {
+        return
+            $"State: {report.DiscordConnectionState}{Environment.NewLine}" +
+            $"Latency: {report.DiscordLatencyMilliseconds} ms{Environment.NewLine}" +
+            $"Guilds: {report.GuildCount}";
+    }
+
+    private static string CreateActiveRunHealthSummary(ActiveRunHealthStatus? activeRun)
+    {
+        if (activeRun is null)
+        {
+            return "No active run.";
+        }
+
+        return TruncateFieldValue(
+            $"Run: {activeRun.Name}{Environment.NewLine}" +
+            $"Edition: {activeRun.Game}{Environment.NewLine}" +
+            $"Players: {activeRun.PlayerCount}{Environment.NewLine}" +
+            $"Routes: {activeRun.LinkGroupCount}{Environment.NewLine}" +
+            $"Team: {activeRun.ActiveTeamCount}/6{Environment.NewLine}" +
+            $"Dead: {activeRun.DeadGroupCount}{Environment.NewLine}" +
+            $"Lost: {activeRun.LostRouteCount}");
+    }
+
+    private static string CreateDataHealthSummary(BotHealthReport report)
+    {
+        var gameData = report.GameDataCatalog;
+        var pokemonCache = report.PokemonDataCache;
+
+        return TruncateFieldValue(
+            $"Game catalog: {FormatReady(gameData.IsReady)} ({gameData.Source}){Environment.NewLine}" +
+            $"Editions/routes: {gameData.EditionCount}/{gameData.RouteCount}{Environment.NewLine}" +
+            $"Refresh running: {FormatYesNo(gameData.IsRefreshRunning)}{Environment.NewLine}" +
+            $"Pokemon cache: {FormatReady(pokemonCache.IsLoaded)} v{pokemonCache.Version}{Environment.NewLine}" +
+            $"Names/info/dex: {pokemonCache.NameIndexCount}/{pokemonCache.PokemonInfoCount}/{pokemonCache.PokedexEntryCount}");
+    }
+
+    private static string CreateRecentDiagnosticsSummary(IReadOnlyList<DiagnosticEvent> recentEvents)
+    {
+        if (recentEvents.Count == 0)
+        {
+            return "No recent warnings or errors recorded.";
+        }
+
+        var lines = recentEvents
+            .Take(8)
+            .Select(FormatDiagnosticEvent);
+
+        return TruncateFieldValue(string.Join(Environment.NewLine, lines));
+    }
+
+    private static string FormatDiagnosticEvent(DiagnosticEvent diagnosticEvent)
+    {
+        var commandText = string.IsNullOrWhiteSpace(diagnosticEvent.CommandName)
+            ? diagnosticEvent.Source
+            : $"/{diagnosticEvent.CommandName}";
+        var exceptionText = string.IsNullOrWhiteSpace(diagnosticEvent.ExceptionType)
+            ? string.Empty
+            : $" · {diagnosticEvent.ExceptionType}";
+        var elapsedText = diagnosticEvent.ElapsedMilliseconds is null
+            ? string.Empty
+            : $" · {diagnosticEvent.ElapsedMilliseconds} ms";
+        var parametersText = string.IsNullOrWhiteSpace(diagnosticEvent.Parameters)
+            ? string.Empty
+            : $" · {diagnosticEvent.Parameters}";
+        var messageText = string.IsNullOrWhiteSpace(diagnosticEvent.ExceptionMessage)
+            ? diagnosticEvent.Message
+            : diagnosticEvent.ExceptionMessage;
+
+        return
+            $"{diagnosticEvent.OccurredAtUtc:HH:mm:ss} UTC · {diagnosticEvent.Severity} · {commandText}" +
+            $"{exceptionText}{elapsedText}{parametersText} · {messageText}";
+    }
+
+    private static string FormatReady(bool isReady)
+    {
+        return isReady ? "ready" : "not ready";
+    }
+
+    private static string FormatYesNo(bool value)
+    {
+        return value ? "yes" : "no";
     }
 
     private IReadOnlyList<string> CreateStatusBlocks(SoulLinkRun run)

--- a/PokeSoulLinkBot/Bot/Program.cs
+++ b/PokeSoulLinkBot/Bot/Program.cs
@@ -8,6 +8,8 @@ using PokeSoulLinkBot.Bot.Factories;
 using PokeSoulLinkBot.Bot.Handlers;
 using PokeSoulLinkBot.Bot.Presentation;
 using PokeSoulLinkBot.Bot.Registration;
+using PokeSoulLinkBot.Bot.Services;
+using PokeSoulLinkBot.Core.Models;
 using PokeSoulLinkBot.Infrastructure.Persistence;
 using Serilog;
 using Serilog.Events;
@@ -83,6 +85,13 @@ internal sealed class Program
         var runStore = new RunStore(filePath);
         var runService = new RunService(runStore);
         var catchEligibilityService = new CatchEligibilityService(runService, pokedexService);
+        var diagnosticsService = new BotDiagnosticsService();
+        var healthService = new BotHealthService(
+            client,
+            runService,
+            gameDataCatalogService,
+            pokemonDataCacheStore,
+            diagnosticsService);
         var embedFactory = new EmbedFactory();
         var embedImageFactory = new EmbedImageFactory(resourcesDirectoryPath);
 
@@ -101,13 +110,14 @@ internal sealed class Program
             new UseCommand(runService, embedFactory, embedImageFactory),
             new PokedexCommand(pokedexService, pokedexPresenter),
             new ArenaCommand(arenaInfoService, embedFactory, embedImageFactory, gameDataCatalogService, runService),
+            new HealthCommand(healthService, embedFactory),
         };
 
-        var slashCommandRouter = new SlashCommandRouter(commands, embedFactory);
+        var slashCommandRouter = new SlashCommandRouter(commands, embedFactory, diagnosticsService);
         var slashCommandRegistrationService = new SlashCommandRegistrationService();
         var readyStartupTaskRunner = new ReadyStartupTaskRunner(RegisterCommandsAfterReadyAsync);
 
-        client.Log += OnLogAsync;
+        client.Log += logMessage => OnLogAsync(logMessage, diagnosticsService);
         client.Ready += readyStartupTaskRunner.HandleReadyAsync;
         client.SlashCommandExecuted += slashCommandRouter.HandleAsync;
         client.AutocompleteExecuted += slashCommandRouter.HandleAutocompleteAsync;
@@ -143,6 +153,11 @@ internal sealed class Program
             catch (Exception exception)
             {
                 Log.Error(exception, "Ready startup failed.");
+                diagnosticsService.RecordException(
+                    "Error",
+                    "ReadyStartup",
+                    "Ready startup failed.",
+                    exception);
             }
         }
 
@@ -158,6 +173,11 @@ internal sealed class Program
             catch (Exception exception)
             {
                 Log.Warning(exception, "Pokemon data cache warmup failed.");
+                diagnosticsService.RecordException(
+                    "Warning",
+                    "PokemonDataWarmup",
+                    "Pokemon data cache warmup failed.",
+                    exception);
             }
         }
 
@@ -242,7 +262,7 @@ internal sealed class Program
         }
     }
 
-    private static Task OnLogAsync(LogMessage logMessage)
+    private static Task OnLogAsync(LogMessage logMessage, BotDiagnosticsService diagnosticsService)
     {
         var level = MapDiscordLogLevel(logMessage.Severity);
         var message = string.IsNullOrWhiteSpace(logMessage.Message)
@@ -252,12 +272,54 @@ internal sealed class Program
         if (logMessage.Exception is not null)
         {
             Log.Write(level, logMessage.Exception, "Discord {Source}: {Message}", logMessage.Source, message);
+            RecordDiscordDiagnostic(logMessage, diagnosticsService, message);
             return Task.CompletedTask;
         }
 
         Log.Write(level, "Discord {Source}: {Message}", logMessage.Source, message);
+        RecordDiscordDiagnostic(logMessage, diagnosticsService, message);
 
         return Task.CompletedTask;
+    }
+
+    private static void RecordDiscordDiagnostic(
+        LogMessage logMessage,
+        BotDiagnosticsService diagnosticsService,
+        string message)
+    {
+        if (logMessage.Severity is not LogSeverity.Critical and not LogSeverity.Error and not LogSeverity.Warning)
+        {
+            return;
+        }
+
+        if (logMessage.Exception is not null)
+        {
+            diagnosticsService.RecordException(
+                MapDiagnosticSeverity(logMessage.Severity),
+                $"Discord:{logMessage.Source}",
+                message,
+                logMessage.Exception);
+            return;
+        }
+
+        diagnosticsService.Record(new DiagnosticEvent
+        {
+            OccurredAtUtc = DateTimeOffset.UtcNow,
+            Severity = MapDiagnosticSeverity(logMessage.Severity),
+            Source = $"Discord:{logMessage.Source}",
+            Message = message,
+        });
+    }
+
+    private static string MapDiagnosticSeverity(LogSeverity severity)
+    {
+        return severity switch
+        {
+            LogSeverity.Critical => "Fatal",
+            LogSeverity.Error => "Error",
+            LogSeverity.Warning => "Warning",
+            _ => "Info",
+        };
     }
 
     private static LogEventLevel MapDiscordLogLevel(LogSeverity severity)

--- a/PokeSoulLinkBot/Bot/Services/BotHealthService.cs
+++ b/PokeSoulLinkBot/Bot/Services/BotHealthService.cs
@@ -1,0 +1,82 @@
+using Discord.WebSocket;
+using PokeSoulLinkBot.Application.Interfaces;
+using PokeSoulLinkBot.Application.Services;
+using PokeSoulLinkBot.Core.Models;
+
+namespace PokeSoulLinkBot.Bot.Services;
+
+/// <summary>
+/// Creates diagnostic snapshots for the bot.
+/// </summary>
+public sealed class BotHealthService : IBotHealthService
+{
+    private const int RecentDiagnosticEventCount = 8;
+
+    private readonly DiscordSocketClient client;
+    private readonly IRunService runService;
+    private readonly IGameDataCatalogService gameDataCatalogService;
+    private readonly PokemonDataCacheStore pokemonDataCacheStore;
+    private readonly IBotDiagnosticsService diagnosticsService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BotHealthService"/> class.
+    /// </summary>
+    /// <param name="client">The Discord client.</param>
+    /// <param name="runService">The run service.</param>
+    /// <param name="gameDataCatalogService">The game-data catalog service.</param>
+    /// <param name="pokemonDataCacheStore">The Pokémon data cache store.</param>
+    /// <param name="diagnosticsService">The diagnostics service.</param>
+    public BotHealthService(
+        DiscordSocketClient client,
+        IRunService runService,
+        IGameDataCatalogService gameDataCatalogService,
+        PokemonDataCacheStore pokemonDataCacheStore,
+        IBotDiagnosticsService diagnosticsService)
+    {
+        this.client = client ?? throw new ArgumentNullException(nameof(client));
+        this.runService = runService ?? throw new ArgumentNullException(nameof(runService));
+        this.gameDataCatalogService = gameDataCatalogService ?? throw new ArgumentNullException(nameof(gameDataCatalogService));
+        this.pokemonDataCacheStore = pokemonDataCacheStore ?? throw new ArgumentNullException(nameof(pokemonDataCacheStore));
+        this.diagnosticsService = diagnosticsService ?? throw new ArgumentNullException(nameof(diagnosticsService));
+    }
+
+    /// <inheritdoc />
+    public async Task<BotHealthReport> GetReportAsync(string guildId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(guildId);
+
+        return new BotHealthReport
+        {
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            DiscordConnectionState = this.client.ConnectionState.ToString(),
+            DiscordLatencyMilliseconds = this.client.Latency,
+            GuildCount = this.client.Guilds.Count,
+            ActiveRun = this.GetActiveRunStatus(guildId),
+            GameDataCatalog = this.gameDataCatalogService.GetStatus(),
+            PokemonDataCache = await this.pokemonDataCacheStore.GetStatusAsync(),
+            RecentEvents = this.diagnosticsService.GetRecentEvents(RecentDiagnosticEventCount),
+        };
+    }
+
+    private ActiveRunHealthStatus? GetActiveRunStatus(string guildId)
+    {
+        try
+        {
+            var activeRun = this.runService.GetActiveRun(guildId);
+            return new ActiveRunHealthStatus
+            {
+                Name = activeRun.Name,
+                Game = activeRun.Game,
+                PlayerCount = activeRun.Players.Count,
+                LinkGroupCount = activeRun.LinkGroups.Count,
+                ActiveTeamCount = activeRun.ActiveLinks.Count(linkGroup => linkGroup is not null),
+                DeadGroupCount = activeRun.LinkGroups.Count(group => group.Entries.Count > 0 && !group.IsAlive),
+                LostRouteCount = activeRun.LinkGroups.Count(group => group.IsLostWithoutEncounter),
+            };
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+}

--- a/PokeSoulLinkBot/Bot/SlashCommandRouter.cs
+++ b/PokeSoulLinkBot/Bot/SlashCommandRouter.cs
@@ -1,9 +1,11 @@
 using System.Text.Json;
 using Discord;
 using Discord.WebSocket;
+using PokeSoulLinkBot.Application.Interfaces;
 using PokeSoulLinkBot.Bot.Commands;
 using PokeSoulLinkBot.Bot.Factories;
 using PokeSoulLinkBot.Bot.Helpers;
+using PokeSoulLinkBot.Core.Models;
 using Serilog;
 
 namespace PokeSoulLinkBot.Bot.Handlers;
@@ -17,6 +19,7 @@ public sealed class SlashCommandRouter
     private const long SlowAutocompleteThresholdMilliseconds = 500;
 
     private readonly IReadOnlyDictionary<string, ISlashCommand> commands;
+    private readonly IBotDiagnosticsService diagnosticsService;
     private readonly EmbedFactory embedFactory;
 
     /// <summary>
@@ -24,14 +27,17 @@ public sealed class SlashCommandRouter
     /// </summary>
     /// <param name="commands">The available slash commands.</param>
     /// <param name="embedFactory">The embed factory used for error messages.</param>
+    /// <param name="diagnosticsService">The diagnostics service.</param>
     public SlashCommandRouter(
         IReadOnlyCollection<ISlashCommand> commands,
-        EmbedFactory embedFactory)
+        EmbedFactory embedFactory,
+        IBotDiagnosticsService diagnosticsService)
     {
         ArgumentNullException.ThrowIfNull(commands);
 
         this.commands = commands.ToDictionary(command => command.CommandName, StringComparer.OrdinalIgnoreCase);
         this.embedFactory = embedFactory ?? throw new ArgumentNullException(nameof(embedFactory));
+        this.diagnosticsService = diagnosticsService ?? throw new ArgumentNullException(nameof(diagnosticsService));
     }
 
     /// <summary>
@@ -87,6 +93,16 @@ public sealed class SlashCommandRouter
                     "Slash command /{CommandName} completed slowly in {ElapsedMilliseconds} ms.",
                     command.CommandName,
                     elapsedMilliseconds);
+                this.diagnosticsService.Record(new DiagnosticEvent
+                {
+                    OccurredAtUtc = DateTimeOffset.UtcNow,
+                    Severity = "Warning",
+                    Source = "SlashCommandRouter",
+                    Message = "Slash command completed slowly.",
+                    CommandName = command.CommandName,
+                    Parameters = parameterText,
+                    ElapsedMilliseconds = elapsedMilliseconds,
+                });
             }
             else
             {
@@ -105,12 +121,20 @@ public sealed class SlashCommandRouter
                 command.CommandName,
                 elapsedMilliseconds,
                 parameterText);
+            this.diagnosticsService.RecordException(
+                "Error",
+                "SlashCommandRouter",
+                "Slash command failed.",
+                exception,
+                command.CommandName,
+                parameterText,
+                elapsedMilliseconds);
 
             var errorMessage = CreateUserFacingErrorMessage(command, exception);
             var errorEmbed = this.embedFactory.CreateErrorEmbed(errorMessage);
 
             response ??= new DiscordSlashCommandResponse(command);
-            await TrySendErrorResponseAsync(response, errorEmbed, exception);
+            await this.TrySendErrorResponseAsync(response, errorEmbed, exception);
         }
     }
 
@@ -174,6 +198,14 @@ public sealed class SlashCommandRouter
                 currentOptionName,
                 currentValue,
                 GetElapsedMilliseconds(startedAt));
+            this.diagnosticsService.RecordException(
+                "Error",
+                "SlashCommandRouter",
+                "Autocomplete failed.",
+                exception,
+                interaction.Data.CommandName,
+                $"{currentOptionName}={currentValue}",
+                GetElapsedMilliseconds(startedAt));
 
             if (!interaction.HasResponded)
             {
@@ -185,25 +217,6 @@ public sealed class SlashCommandRouter
     private static long GetElapsedMilliseconds(DateTimeOffset startedAt)
     {
         return (long)(DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
-    }
-
-    private static async Task TrySendErrorResponseAsync(
-        ISlashCommandResponse response,
-        Embed errorEmbed,
-        Exception originalException)
-    {
-        try
-        {
-            await response.SendAsync(embed: errorEmbed, ephemeral: true);
-        }
-        catch (Exception responseException)
-        {
-            Log.ForContext("EventName", "SlashCommandErrorResponseFailed").Warning(
-                responseException,
-                "Could not send error response for slash command /{CommandName}. OriginalException={OriginalExceptionType}.",
-                response.CommandName,
-                originalException.GetType().Name);
-        }
     }
 
     private static string FormatCommandOptions(SocketSlashCommand command)
@@ -308,5 +321,30 @@ public sealed class SlashCommandRouter
         }
 
         return fallbackMessage;
+    }
+
+    private async Task TrySendErrorResponseAsync(
+        ISlashCommandResponse response,
+        Embed errorEmbed,
+        Exception originalException)
+    {
+        try
+        {
+            await response.SendAsync(embed: errorEmbed, ephemeral: true);
+        }
+        catch (Exception responseException)
+        {
+            Log.ForContext("EventName", "SlashCommandErrorResponseFailed").Warning(
+                responseException,
+                "Could not send error response for slash command /{CommandName}. OriginalException={OriginalExceptionType}.",
+                response.CommandName,
+                originalException.GetType().Name);
+            this.diagnosticsService.RecordException(
+                "Warning",
+                "SlashCommandRouter",
+                "Could not send slash-command error response.",
+                responseException,
+                response.CommandName);
+        }
     }
 }

--- a/PokeSoulLinkBot/Core/Models/ActiveRunHealthStatus.cs
+++ b/PokeSoulLinkBot/Core/Models/ActiveRunHealthStatus.cs
@@ -1,0 +1,42 @@
+namespace PokeSoulLinkBot.Core.Models;
+
+/// <summary>
+/// Represents a compact diagnostic summary of the active run.
+/// </summary>
+public sealed class ActiveRunHealthStatus
+{
+    /// <summary>
+    /// Gets or sets the run name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the game edition.
+    /// </summary>
+    public string Game { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the number of players in the run.
+    /// </summary>
+    public int PlayerCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of recorded link groups.
+    /// </summary>
+    public int LinkGroupCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of active team slots.
+    /// </summary>
+    public int ActiveTeamCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of dead link groups.
+    /// </summary>
+    public int DeadGroupCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of routes lost without a catch.
+    /// </summary>
+    public int LostRouteCount { get; set; }
+}

--- a/PokeSoulLinkBot/Core/Models/BotHealthReport.cs
+++ b/PokeSoulLinkBot/Core/Models/BotHealthReport.cs
@@ -1,0 +1,47 @@
+namespace PokeSoulLinkBot.Core.Models;
+
+/// <summary>
+/// Represents a shareable diagnostic snapshot of the bot state.
+/// </summary>
+public sealed class BotHealthReport
+{
+    /// <summary>
+    /// Gets or sets the UTC date and time when the report was created.
+    /// </summary>
+    public DateTimeOffset CreatedAtUtc { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Gets or sets the Discord connection state.
+    /// </summary>
+    public string DiscordConnectionState { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Discord gateway latency in milliseconds.
+    /// </summary>
+    public int DiscordLatencyMilliseconds { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of guilds visible to the bot.
+    /// </summary>
+    public int GuildCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the active run summary.
+    /// </summary>
+    public ActiveRunHealthStatus? ActiveRun { get; set; }
+
+    /// <summary>
+    /// Gets or sets the game-data catalog status.
+    /// </summary>
+    public GameDataCatalogStatus GameDataCatalog { get; set; } = new GameDataCatalogStatus();
+
+    /// <summary>
+    /// Gets or sets the Pokémon data cache status.
+    /// </summary>
+    public PokemonDataCacheStatus PokemonDataCache { get; set; } = new PokemonDataCacheStatus();
+
+    /// <summary>
+    /// Gets or sets recent diagnostic events.
+    /// </summary>
+    public IReadOnlyList<DiagnosticEvent> RecentEvents { get; set; } = Array.Empty<DiagnosticEvent>();
+}

--- a/PokeSoulLinkBot/Core/Models/DiagnosticEvent.cs
+++ b/PokeSoulLinkBot/Core/Models/DiagnosticEvent.cs
@@ -1,0 +1,52 @@
+namespace PokeSoulLinkBot.Core.Models;
+
+/// <summary>
+/// Represents a recent diagnostic event that can help troubleshoot bot problems after they occurred.
+/// </summary>
+public sealed class DiagnosticEvent
+{
+    /// <summary>
+    /// Gets or sets the UTC date and time when the event occurred.
+    /// </summary>
+    public DateTimeOffset OccurredAtUtc { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Gets or sets the event severity.
+    /// </summary>
+    public string Severity { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the component that recorded the event.
+    /// </summary>
+    public string Source { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the short event message.
+    /// </summary>
+    public string Message { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the slash command name related to the event, if any.
+    /// </summary>
+    public string? CommandName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the formatted command parameters related to the event, if any.
+    /// </summary>
+    public string? Parameters { get; set; }
+
+    /// <summary>
+    /// Gets or sets the exception type related to the event, if any.
+    /// </summary>
+    public string? ExceptionType { get; set; }
+
+    /// <summary>
+    /// Gets or sets a safe exception message related to the event, if any.
+    /// </summary>
+    public string? ExceptionMessage { get; set; }
+
+    /// <summary>
+    /// Gets or sets the elapsed command duration in milliseconds, if available.
+    /// </summary>
+    public long? ElapsedMilliseconds { get; set; }
+}

--- a/PokeSoulLinkBot/Core/Models/GameDataCatalogStatus.cs
+++ b/PokeSoulLinkBot/Core/Models/GameDataCatalogStatus.cs
@@ -1,0 +1,42 @@
+namespace PokeSoulLinkBot.Core.Models;
+
+/// <summary>
+/// Represents the current state of the game-data catalog used for edition and route suggestions.
+/// </summary>
+public sealed class GameDataCatalogStatus
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether a catalog is currently loaded.
+    /// </summary>
+    public bool IsReady { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source of the currently loaded catalog.
+    /// </summary>
+    public string Source { get; set; } = "none";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a background refresh is currently running.
+    /// </summary>
+    public bool IsRefreshRunning { get; set; }
+
+    /// <summary>
+    /// Gets or sets the catalog schema version.
+    /// </summary>
+    public int? SchemaVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC date and time when the catalog was last refreshed.
+    /// </summary>
+    public DateTime? RefreshedAtUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of known game editions.
+    /// </summary>
+    public int EditionCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of known routes across all editions.
+    /// </summary>
+    public int RouteCount { get; set; }
+}

--- a/PokeSoulLinkBot/Core/Models/PokemonDataCacheStatus.cs
+++ b/PokeSoulLinkBot/Core/Models/PokemonDataCacheStatus.cs
@@ -1,0 +1,37 @@
+namespace PokeSoulLinkBot.Core.Models;
+
+/// <summary>
+/// Represents the current state of the persistent Pokémon data cache.
+/// </summary>
+public sealed class PokemonDataCacheStatus
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the cache has been loaded into memory.
+    /// </summary>
+    public bool IsLoaded { get; set; }
+
+    /// <summary>
+    /// Gets or sets the cache schema version.
+    /// </summary>
+    public int Version { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC date and time when the cache was last refreshed.
+    /// </summary>
+    public DateTime RefreshedAtUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of cached localized Pokémon names.
+    /// </summary>
+    public int NameIndexCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of cached Pokémon metadata entries.
+    /// </summary>
+    public int PokemonInfoCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of cached Pokédex entries.
+    /// </summary>
+    public int PokedexEntryCount { get; set; }
+}


### PR DESCRIPTION
Ticket: https://github.com/mpiechot/PokemonSoulLinkDiscord/issues/31

## Summary

- Adds `/health` to show Discord state, active run summary, game-data catalog status, Pokemon cache counters, and recent diagnostics.
- Adds an in-memory diagnostics ring buffer for recent command, autocomplete, startup, warmup, and Discord.Net warnings/errors.
- Records enough safe context after failures so the command output can be shared for troubleshooting without exposing tokens or local file paths.
- Adds cache/catalog status snapshots and tests for diagnostics storage, health embed output, and command registration.

## Verification

- `dotnet format PokeSoulLinkBot\PokeSoulLinkBot.slnx --no-restore`
- `dotnet test PokeSoulLinkBot\PokeSoulLinkBot.slnx --no-restore -p:UseAppHost=false`
- `git diff --check`
- `git ls-files --eol` for staged text files

Closes #31.