### PR TITLE
Restore full-width status tables

### DIFF
--- a/PokeSoulLinkBot.Tests/EmbedFactoryStatusTests.cs
+++ b/PokeSoulLinkBot.Tests/EmbedFactoryStatusTests.cs
@@ -19,9 +19,9 @@ public sealed class EmbedFactoryStatusTests
 
         var message = embedFactory.CreateStatusMessage(run);
 
-        Assert.Contains("Current Team", message, StringComparison.Ordinal);
-        Assert.Contains("Box", message, StringComparison.Ordinal);
-        Assert.Contains("Dead", message, StringComparison.Ordinal);
+        Assert.Contains("⚔️ Current Team", message, StringComparison.Ordinal);
+        Assert.Contains("📦 Box", message, StringComparison.Ordinal);
+        Assert.Contains("💀 Dead", message, StringComparison.Ordinal);
         Assert.DoesNotContain("Alive", message, StringComparison.Ordinal);
         Assert.Contains("101", message, StringComparison.Ordinal);
         Assert.Contains("102", message, StringComparison.Ordinal);
@@ -190,76 +190,16 @@ public sealed class EmbedFactoryStatusTests
         var messages = embedFactory.CreateStatusMessages(run);
         var fullMessage = string.Join(Environment.NewLine, messages);
 
-        Assert.Contains("**Current Team**", fullMessage, StringComparison.Ordinal);
-        Assert.Contains("**Box**", fullMessage, StringComparison.Ordinal);
-        Assert.Contains("**Dead**", fullMessage, StringComparison.Ordinal);
+        Assert.Contains("**⚔️ Current Team**", fullMessage, StringComparison.Ordinal);
+        Assert.Contains("**📦 Box**", fullMessage, StringComparison.Ordinal);
+        Assert.Contains("**💀 Dead**", fullMessage, StringComparison.Ordinal);
+        Assert.Contains("```", fullMessage, StringComparison.Ordinal);
         Assert.DoesNotContain("(continued)", fullMessage, StringComparison.Ordinal);
         Assert.DoesNotContain("...```", fullMessage, StringComparison.Ordinal);
         Assert.All(messages, message => Assert.InRange(message.Length, 1, 2000));
         for (var routeIndex = 1; routeIndex <= 80; routeIndex++)
         {
             Assert.Contains($"route-{routeIndex:000}", fullMessage, StringComparison.Ordinal);
-        }
-    }
-
-    [Fact]
-    public void CreateStatusEmbedBatches_ShouldKeepTypicalStatusInOneDiscordMessage()
-    {
-        var run = CreateRunWithPlayers("marpie1", "beneerdbeermarmelade", "darkstyle4957");
-        for (var routeIndex = 1; routeIndex <= 18; routeIndex++)
-        {
-            var linkGroup = CreateLinkGroup($"route-{routeIndex:000}", routeIndex <= 12, $"Pokemon-{routeIndex:000}");
-            foreach (var player in run.Players.Skip(1))
-            {
-                linkGroup.Entries.Add(new LinkedPokemon
-                {
-                    PlayerUserId = player.UserId,
-                    PlayerName = player.UserName,
-                    PokemonName = $"Pokemon-{player.UserId}-{routeIndex:000}",
-                    IsAlive = routeIndex <= 12,
-                });
-            }
-
-            run.LinkGroups.Add(linkGroup);
-            if (routeIndex <= 6)
-            {
-                run.ActiveLinks[routeIndex - 1] = linkGroup;
-            }
-        }
-
-        var embedFactory = new EmbedFactory();
-
-        var batches = embedFactory.CreateStatusEmbedBatches(run, "attachment://status.png");
-
-        var batch = Assert.Single(batches);
-        Assert.InRange(batch.Count, 1, 10);
-        Assert.Contains(batch, embed => embed.Title == "Run Status");
-        Assert.Contains(batch, embed => embed.Description?.Contains("**Current Team**", StringComparison.Ordinal) == true);
-        Assert.Contains(batch, embed => embed.Description?.Contains("**Box**", StringComparison.Ordinal) == true);
-        Assert.Contains(batch, embed => embed.Description?.Contains("**Dead**", StringComparison.Ordinal) == true);
-    }
-
-    [Fact]
-    public void CreateStatusEmbedBatches_ShouldRespectDiscordEmbedBatchLimits()
-    {
-        var run = CreateRun();
-        for (var routeIndex = 1; routeIndex <= 180; routeIndex++)
-        {
-            run.LinkGroups.Add(CreateLinkGroup($"route-{routeIndex:000}", true, $"Pokemon-{routeIndex:000}"));
-        }
-
-        var embedFactory = new EmbedFactory();
-
-        var batches = embedFactory.CreateStatusEmbedBatches(run, "attachment://status.png");
-        var fullDescriptions = string.Join(
-            Environment.NewLine,
-            batches.SelectMany(batch => batch).Select(embed => embed.Description));
-
-        Assert.All(batches, batch => Assert.InRange(batch.Count, 1, 10));
-        Assert.All(batches, batch => Assert.InRange(GetEmbedBatchLength(batch), 1, 6000));
-        for (var routeIndex = 1; routeIndex <= 180; routeIndex++)
-        {
-            Assert.Contains($"route-{routeIndex:000}", fullDescriptions, StringComparison.Ordinal);
         }
     }
 
@@ -288,20 +228,6 @@ public sealed class EmbedFactoryStatusTests
         }
 
         return run;
-    }
-
-    private static int GetEmbedBatchLength(IReadOnlyCollection<Discord.Embed> embeds)
-    {
-        return embeds.Sum(embed =>
-            (embed.Title?.Length ?? 0)
-            + (embed.Description?.Length ?? 0)
-            + embed.Fields.Sum(GetEmbedFieldLength));
-    }
-
-    private static int GetEmbedFieldLength(Discord.EmbedField field)
-    {
-        var fieldValue = Convert.ToString(field.Value);
-        return field.Name.Length + (fieldValue?.Length ?? 0);
     }
 
     private static LinkGroup CreateLinkGroup(string route, bool isAlive, string pokemonName)

--- a/PokeSoulLinkBot.Tests/SlashCommandResponsePatternTests.cs
+++ b/PokeSoulLinkBot.Tests/SlashCommandResponsePatternTests.cs
@@ -76,15 +76,16 @@ public sealed class SlashCommandResponsePatternTests
     }
 
     [Fact]
-    public void StatusCommand_ShouldUseEmbedBatchesForVisualContinuity()
+    public void StatusCommand_ShouldUsePagedFullWidthStatusMessages()
     {
         var source = ReadSourceFile("PokeSoulLinkBot", "Bot", "Commands", "StatusCommand.cs");
         var handleAsyncBody = ExtractMethodBody(source, "public async Task HandleAsync(SocketSlashCommand command, ISlashCommandResponse response)");
 
-        Assert.Contains("this.embedFactory.CreateStatusEmbedBatches(activeRun, image.AttachmentUrl)", handleAsyncBody, StringComparison.Ordinal);
-        Assert.Contains("response.SendFilesAsync(new[] { image.FileAttachment }, embeds: firstEmbedBatch)", handleAsyncBody, StringComparison.Ordinal);
-        Assert.Contains("response.SendEmbedsAsync(embedBatch)", handleAsyncBody, StringComparison.Ordinal);
-        Assert.DoesNotContain("response.SendFollowupsAsync", handleAsyncBody, StringComparison.Ordinal);
+        Assert.Contains("this.embedFactory.CreateStatusMessages(activeRun)", handleAsyncBody, StringComparison.Ordinal);
+        Assert.Contains("response.SendFileAsync(image.FileAttachment, text: messages[0], embed: embed)", handleAsyncBody, StringComparison.Ordinal);
+        Assert.Contains("response.SendFollowupsAsync(messages.Skip(1))", handleAsyncBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("CreateStatusEmbedBatches", handleAsyncBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("SendEmbedsAsync", handleAsyncBody, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/PokeSoulLinkBot/Bot/Commands/StatusCommand.cs
+++ b/PokeSoulLinkBot/Bot/Commands/StatusCommand.cs
@@ -65,15 +65,12 @@ public class StatusCommand : ISlashCommand
         var activeRun = this.runService.GetActiveRun(guildId);
         await this.EnrichMissingPokemonTypesAsync(activeRun);
 
+        var messages = this.embedFactory.CreateStatusMessages(activeRun);
         var image = this.embedImageFactory.CreateStatusImage();
-        var embedBatches = this.embedFactory.CreateStatusEmbedBatches(activeRun, image.AttachmentUrl);
-        var firstEmbedBatch = embedBatches.First();
-        await response.SendFilesAsync(new[] { image.FileAttachment }, embeds: firstEmbedBatch);
+        var embed = this.embedFactory.CreateRunSummaryEmbed("Run Status", activeRun, image.AttachmentUrl);
+        await response.SendFileAsync(image.FileAttachment, text: messages[0], embed: embed);
 
-        foreach (var embedBatch in embedBatches.Skip(1))
-        {
-            await response.SendEmbedsAsync(embedBatch);
-        }
+        await response.SendFollowupsAsync(messages.Skip(1));
     }
 
     private async Task EnrichMissingPokemonTypesAsync(SoulLinkRun run)

--- a/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
+++ b/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Text;
 using Discord;
 using PokeSoulLinkBot.Bot.Helpers;
@@ -12,8 +11,6 @@ namespace PokeSoulLinkBot.Bot.Factories;
 public sealed class EmbedFactory
 {
     private const int DiscordMessageMaxLength = 2000;
-    private const int DiscordEmbedsPerMessageMaxCount = 10;
-    private const int DiscordEmbedsPerMessageMaxCharacters = 6000;
 
     /// <summary>
     /// Creates an embed for a newly started run.
@@ -283,27 +280,6 @@ public sealed class EmbedFactory
     }
 
     /// <summary>
-    /// Creates Discord-compatible status embed batches for the active run.
-    /// </summary>
-    /// <param name="run">The active run.</param>
-    /// <param name="thumbnailUrl">The attachment URL of the thumbnail shown in the first embed.</param>
-    /// <returns>The paged status embed batches.</returns>
-    public IReadOnlyList<IReadOnlyList<Embed>> CreateStatusEmbedBatches(SoulLinkRun run, string thumbnailUrl)
-    {
-        ArgumentNullException.ThrowIfNull(run);
-        ArgumentException.ThrowIfNullOrWhiteSpace(thumbnailUrl);
-
-        var embeds = new List<Embed>
-        {
-            this.CreateRunSummaryEmbed("Run Status", run, thumbnailUrl),
-        };
-
-        embeds.AddRange(this.CreateStatusBlocks(run).Select(CreateStatusBlockEmbed));
-
-        return BatchEmbeds(embeds);
-    }
-
-    /// <summary>
     /// Creates the message for a newly selected active team.
     /// </summary>
     /// <param name="run">The active run.</param>
@@ -536,57 +512,6 @@ public sealed class EmbedFactory
         }
 
         return messages;
-    }
-
-    private static IReadOnlyList<IReadOnlyList<Embed>> BatchEmbeds(IReadOnlyList<Embed> embeds)
-    {
-        var batches = new List<IReadOnlyList<Embed>>();
-        var currentBatch = new List<Embed>();
-        var currentBatchLength = 0;
-
-        foreach (var embed in embeds)
-        {
-            var embedLength = EstimateEmbedLength(embed);
-            if (currentBatch.Count > 0
-                && (currentBatch.Count >= DiscordEmbedsPerMessageMaxCount
-                    || currentBatchLength + embedLength > DiscordEmbedsPerMessageMaxCharacters))
-            {
-                batches.Add(currentBatch);
-                currentBatch = new List<Embed>();
-                currentBatchLength = 0;
-            }
-
-            currentBatch.Add(embed);
-            currentBatchLength += embedLength;
-        }
-
-        if (currentBatch.Count > 0)
-        {
-            batches.Add(currentBatch);
-        }
-
-        return batches;
-    }
-
-    private static Embed CreateStatusBlockEmbed(string block)
-    {
-        return new EmbedBuilder()
-            .WithColor(Color.Blue)
-            .WithDescription(block)
-            .Build();
-    }
-
-    private static int EstimateEmbedLength(Embed embed)
-    {
-        var fieldsLength = embed.Fields.Sum(field =>
-        {
-            var fieldValue = Convert.ToString(field.Value, CultureInfo.InvariantCulture);
-            return field.Name.Length + (fieldValue?.Length ?? 0);
-        });
-
-        return (embed.Title?.Length ?? 0)
-            + (embed.Description?.Length ?? 0)
-            + fieldsLength;
     }
 
     private static string JoinBlocks(IReadOnlyList<string> blocks)
@@ -825,9 +750,9 @@ public sealed class EmbedFactory
         var playerNames = run.Players.Select(player => player.UserName).ToList();
         var blocks = new List<string>();
 
-        blocks.AddRange(this.CreateTableSections("Current Team", currentTeam, playerNames));
-        blocks.AddRange(this.CreateTableSections("Box", box, playerNames));
-        blocks.AddRange(this.CreateTableSections("Dead", run.LinkGroups.Where(group => !group.IsAlive), playerNames));
+        blocks.AddRange(this.CreateTableSections("⚔️ Current Team", currentTeam, playerNames));
+        blocks.AddRange(this.CreateTableSections("📦 Box", box, playerNames));
+        blocks.AddRange(this.CreateTableSections("💀 Dead", run.LinkGroups.Where(group => !group.IsAlive), playerNames));
 
         return blocks;
     }


### PR DESCRIPTION
Ticket: https://github.com/mpiechot/PokemonSoulLinkDiscord/issues/54

## Summary
- Render `/status` tables again as full-width Discord message text instead of narrow embed descriptions.
- Restore the section icons for Current Team, Box, and Dead.
- Keep the run summary embed and paged follow-up messages for long status output.
- Remove the status embed batching path and update regression tests around the command response pattern.

## Verification
- dotnet format PokeSoulLinkBot\PokeSoulLinkBot.slnx --no-restore
- dotnet test PokeSoulLinkBot\PokeSoulLinkBot.slnx --no-restore -p:UseAppHost=false
- git diff --check
- git ls-files --eol

Closes #54.
