### PR TITLE
Add an isolated console publish workflow

### DIFF
--- a/docs/build-and-publish.md
+++ b/docs/build-and-publish.md
@@ -1,0 +1,94 @@
+# Bot bauen und veroeffentlichen
+
+Der Bot wird als framework-abhaengige .NET-9-Konsolenanwendung veroeffentlicht. Der Publish-Output liegt bewusst unter `artifacts/publish/PokeSoulLinkBot` und damit ausserhalb von `bin/Debug`, `bin/Release` und `obj`. Visual Studio und laufende Debug-Builds werden dadurch nicht blockiert.
+
+## Voraussetzungen
+
+- .NET SDK 9 oder neuer
+- PowerShell 7 oder Windows PowerShell 5.1
+- Zugriff auf NuGet fuer einen erstmaligen Restore
+
+## Empfohlener Publish-Build
+
+Im Repository-Root:
+
+```powershell
+./scripts/publish-bot.ps1
+```
+
+Das Script:
+
+- prueft die installierte .NET-SDK-Version;
+- verhindert einen Output unter `PokeSoulLinkBot/bin` oder `PokeSoulLinkBot/obj`;
+- erstellt einen Release-Publish unter `artifacts/publish/PokeSoulLinkBot`;
+- veroeffentlicht framework-abhaengig und ohne plattformspezifischen AppHost;
+- prueft die erzeugte DLL, `.deps.json`, `.runtimeconfig.json` sowie alle im Projekt vorhandenen Dateien unter `Data` und `Resources`.
+
+Wenn der Restore bereits ausgefuehrt wurde:
+
+```powershell
+./scripts/publish-bot.ps1 -NoRestore
+```
+
+Ein alternatives Ausgabeverzeichnis kann explizit angegeben werden:
+
+```powershell
+./scripts/publish-bot.ps1 -OutputDirectory "C:\Deploy\PokeSoulLinkBot"
+```
+
+Der entsprechende direkte .NET-Befehl lautet:
+
+```powershell
+dotnet publish PokeSoulLinkBot/PokeSoulLinkBot.csproj `
+  --configuration Release `
+  --output artifacts/publish/PokeSoulLinkBot `
+  --no-self-contained `
+  -p:UseAppHost=false
+```
+
+## Konfiguration
+
+Secrets werden nicht in den Publish-Output kopiert. Vor dem Start muss mindestens `DISCORD_BOT_TOKEN` als Umgebungsvariable oder im lokalen User-Secrets-Store des Projekts vorhanden sein.
+
+Optionale Umgebungsvariablen:
+
+- `DISCORD_COMMAND_REGISTRATION_MODE`: `all` (Standard), `global`, `guild`, `guilds` oder `development`
+- `DISCORD_COMMAND_GUILD_IDS`: mit Komma, Semikolon oder Leerzeichen getrennte Guild-IDs; leer bedeutet alle verbundenen Guilds
+
+Die vom SDK erzeugten Dateien `PokeSoulLinkBot.runtimeconfig.json` und `PokeSoulLinkBot.deps.json` enthalten die technische Laufzeitkonfiguration. Bilder unter `Resources` und der Offline-Katalog unter `Data/game-data-fallback.json` werden durch das Projekt mitveroeffentlicht.
+
+## Bot starten
+
+PowerShell:
+
+```powershell
+$env:DISCORD_BOT_TOKEN = "<token>"
+dotnet artifacts/publish/PokeSoulLinkBot/PokeSoulLinkBot.dll
+```
+
+Linux/macOS:
+
+```bash
+export DISCORD_BOT_TOKEN="<token>"
+dotnet artifacts/publish/PokeSoulLinkBot/PokeSoulLinkBot.dll
+```
+
+Der Prozess bleibt im Vordergrund aktiv und schreibt strukturierte Logs in die Konsole. Beenden erfolgt mit `Ctrl+C` oder ueber den Prozessmanager des verwendeten Hosting-Systems.
+
+## Publish-Output pruefen
+
+Mindestens folgende Dateien und Verzeichnisse muessen vorhanden sein:
+
+```text
+artifacts/publish/PokeSoulLinkBot/
+|-- PokeSoulLinkBot.dll
+|-- PokeSoulLinkBot.deps.json
+|-- PokeSoulLinkBot.runtimeconfig.json
+|-- Data/
+|   `-- game-data-fallback.json
+`-- Resources/
+    |-- run-start.png
+    `-- status.png
+```
+
+Weitere abhaengige Assemblies und Ressourcen werden von `dotnet publish` automatisch ergaenzt.

--- a/scripts/publish-bot.ps1
+++ b/scripts/publish-bot.ps1
@@ -1,0 +1,83 @@
+[CmdletBinding()]
+param(
+    [string] $OutputDirectory,
+    [switch] $NoRestore
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repositoryRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
+$projectPath = Join-Path $repositoryRoot "PokeSoulLinkBot\PokeSoulLinkBot.csproj"
+
+if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+    $OutputDirectory = Join-Path $repositoryRoot "artifacts\publish\PokeSoulLinkBot"
+}
+
+$resolvedOutputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
+$projectDirectory = [System.IO.Path]::GetDirectoryName($projectPath)
+$binDirectory = [System.IO.Path]::GetFullPath((Join-Path $projectDirectory "bin"))
+$objDirectory = [System.IO.Path]::GetFullPath((Join-Path $projectDirectory "obj"))
+
+if ($resolvedOutputDirectory.StartsWith($binDirectory, [System.StringComparison]::OrdinalIgnoreCase) -or
+    $resolvedOutputDirectory.StartsWith($objDirectory, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "The publish output must be outside the project's bin and obj directories."
+}
+
+$dotnetVersion = & dotnet --version
+if ($LASTEXITCODE -ne 0) {
+    throw "The .NET SDK could not be executed."
+}
+
+$dotnetMajorVersion = [int]($dotnetVersion.Split('.')[0])
+if ($dotnetMajorVersion -lt 9) {
+    throw ".NET SDK 9 or newer is required. Installed version: $dotnetVersion"
+}
+
+$publishArguments = @(
+    "publish",
+    $projectPath,
+    "--configuration",
+    "Release",
+    "--output",
+    $resolvedOutputDirectory,
+    "--no-self-contained",
+    "-p:UseAppHost=false"
+)
+
+if ($NoRestore) {
+    $publishArguments += "--no-restore"
+}
+
+& dotnet @publishArguments
+if ($LASTEXITCODE -ne 0) {
+    throw "dotnet publish failed with exit code $LASTEXITCODE."
+}
+
+$requiredFiles = [System.Collections.Generic.List[string]]@(
+    "PokeSoulLinkBot.dll",
+    "PokeSoulLinkBot.deps.json",
+    "PokeSoulLinkBot.runtimeconfig.json"
+)
+
+$resourceFiles = Get-ChildItem -LiteralPath (Join-Path $projectDirectory "Resources") -File
+foreach ($resourceFile in $resourceFiles) {
+    $requiredFiles.Add("Resources\$($resourceFile.Name)")
+}
+
+$dataFiles = Get-ChildItem -LiteralPath (Join-Path $projectDirectory "Data") -File
+foreach ($dataFile in $dataFiles) {
+    $requiredFiles.Add("Data\$($dataFile.Name)")
+}
+
+$missingFiles = @(
+    $requiredFiles |
+        Where-Object { -not (Test-Path -LiteralPath (Join-Path $resolvedOutputDirectory $_) -PathType Leaf) }
+)
+
+if ($missingFiles.Count -gt 0) {
+    throw "The publish output is incomplete. Missing: $($missingFiles -join ', ')"
+}
+
+Write-Host "Published PokeSoulLinkBot to $resolvedOutputDirectory"
+Write-Host "Start with: dotnet `"$resolvedOutputDirectory\PokeSoulLinkBot.dll`""


### PR DESCRIPTION
Ticket: https://github.com/mpiechot/PokemonSoulLinkDiscord/issues/16

## Summary
- add a reusable PowerShell publish command with a safe output outside `bin` and `obj`
- validate the runtime files and every bundled `Data` and `Resources` file after publishing
- document configuration, direct `dotnet publish` usage, output contents, and start commands

## User impact
Operators can build and start a Release artifact without occupying Visual Studio's normal Debug output. Missing bundled files fail the publish workflow immediately.

## Verification
- `pwsh -NoProfile -File ./scripts/publish-bot.ps1 -NoRestore -OutputDirectory ./artifacts/publish/bl-007`
- verified generated DLL, dependency/runtime configuration, all data files, and all image resources
- `dotnet test PokeSoulLinkBot.Tests/PokeSoulLinkBot.Tests.csproj --no-restore --verbosity minimal -p:UseAppHost=false -p:UseSharedCompilation=false -p:OutputPath=../artifacts/test/bl-007/` (118 passed)
- `git diff --cached --check`
- both changed files report `w/crlf`

The publish still reports the pre-existing SA0001 project-configuration warning; this PR introduces no analyzer warning.