### PR TITLE
Version and migrate persisted run data

### DIFF
--- a/PokeSoulLinkBot.Tests/RunStoreTests.cs
+++ b/PokeSoulLinkBot.Tests/RunStoreTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using PokeSoulLinkBot.Core.Models;
 using PokeSoulLinkBot.Infrastructure.Persistence;
 using Xunit;
@@ -6,6 +7,102 @@ namespace PokeSoulLinkBot.Tests;
 
 public sealed class RunStoreTests
 {
+    [Fact]
+    public void AddRun_ShouldPersistVersionedDocument()
+    {
+        string filePath = CreateTemporaryRunStorePath();
+        try
+        {
+            var store = new RunStore(filePath);
+
+            store.AddRun(CreateRun("guild-1", "Ruby"));
+
+            using JsonDocument document = JsonDocument.Parse(File.ReadAllText(filePath));
+            JsonElement root = document.RootElement;
+            Assert.Equal(JsonValueKind.Object, root.ValueKind);
+            Assert.Equal(1, root.GetProperty("SchemaVersion").GetInt32());
+            Assert.Single(root.GetProperty("Runs").EnumerateArray());
+        }
+        finally
+        {
+            DeleteTemporaryRunStore(filePath);
+        }
+    }
+
+    [Fact]
+    public void Constructor_ShouldLoadLegacyArrayWithoutSchemaVersion()
+    {
+        string filePath = CreateTemporaryRunStorePath();
+        try
+        {
+            var legacyRuns = new List<SoulLinkRun>
+            {
+                CreateRun("guild-1", "Ruby"),
+            };
+            File.WriteAllText(filePath, JsonSerializer.Serialize(legacyRuns));
+
+            var store = new RunStore(filePath);
+
+            SoulLinkRun? run = store.GetActiveRun("guild-1");
+            Assert.NotNull(run);
+            Assert.Equal("Ruby", run.Name);
+
+            store.Save();
+            using JsonDocument migratedDocument = JsonDocument.Parse(File.ReadAllText(filePath));
+            Assert.Equal(1, migratedDocument.RootElement.GetProperty("SchemaVersion").GetInt32());
+        }
+        finally
+        {
+            DeleteTemporaryRunStore(filePath);
+        }
+    }
+
+    [Fact]
+    public void Constructor_ShouldLoadCurrentVersionedDocument()
+    {
+        string filePath = CreateTemporaryRunStorePath();
+        try
+        {
+            var initialStore = new RunStore(filePath);
+            initialStore.AddRun(CreateRun("guild-1", "Ruby"));
+
+            var reloadedStore = new RunStore(filePath);
+
+            SoulLinkRun? run = reloadedStore.GetActiveRun("guild-1");
+            Assert.NotNull(run);
+            Assert.Equal("Ruby", run.Name);
+        }
+        finally
+        {
+            DeleteTemporaryRunStore(filePath);
+        }
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectNewerSchemaWithoutChangingFile()
+    {
+        string filePath = CreateTemporaryRunStorePath();
+        try
+        {
+            const string newerDocument = """
+                {
+                  "SchemaVersion": 99,
+                  "Runs": []
+                }
+                """;
+            File.WriteAllText(filePath, newerDocument);
+
+            var exception = Assert.Throws<NotSupportedException>(() => new RunStore(filePath));
+
+            Assert.Contains("99", exception.Message, StringComparison.Ordinal);
+            Assert.Equal(newerDocument, File.ReadAllText(filePath));
+        }
+        finally
+        {
+            DeleteTemporaryRunStore(filePath);
+        }
+    }
+
     [Fact]
     public void Constructor_ShouldLoadBackupWhenPrimaryJsonIsCorrupt()
     {

--- a/PokeSoulLinkBot/Persistence/Migrations/IRunStoreMigration.cs
+++ b/PokeSoulLinkBot/Persistence/Migrations/IRunStoreMigration.cs
@@ -1,0 +1,24 @@
+namespace PokeSoulLinkBot.Infrastructure.Persistence.Migrations;
+
+/// <summary>
+/// Migrates one persisted run-store document version to the next version.
+/// </summary>
+internal interface IRunStoreMigration
+{
+    /// <summary>
+    /// Gets the schema version accepted by the migration.
+    /// </summary>
+    int SourceVersion { get; }
+
+    /// <summary>
+    /// Gets the schema version produced by the migration.
+    /// </summary>
+    int TargetVersion { get; }
+
+    /// <summary>
+    /// Migrates the supplied document.
+    /// </summary>
+    /// <param name="document">The source document.</param>
+    /// <returns>The migrated document.</returns>
+    RunStoreDocument Migrate(RunStoreDocument document);
+}

--- a/PokeSoulLinkBot/Persistence/Migrations/LegacyRunStoreMigration.cs
+++ b/PokeSoulLinkBot/Persistence/Migrations/LegacyRunStoreMigration.cs
@@ -1,0 +1,25 @@
+namespace PokeSoulLinkBot.Infrastructure.Persistence.Migrations;
+
+/// <summary>
+/// Migrates the legacy unversioned run collection to the first versioned document.
+/// </summary>
+internal sealed class LegacyRunStoreMigration : IRunStoreMigration
+{
+    /// <inheritdoc />
+    public int SourceVersion => 0;
+
+    /// <inheritdoc />
+    public int TargetVersion => 1;
+
+    /// <inheritdoc />
+    public RunStoreDocument Migrate(RunStoreDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        return new RunStoreDocument
+        {
+            SchemaVersion = this.TargetVersion,
+            Runs = document.Runs ?? new (),
+        };
+    }
+}

--- a/PokeSoulLinkBot/Persistence/Migrations/RunStoreDocument.cs
+++ b/PokeSoulLinkBot/Persistence/Migrations/RunStoreDocument.cs
@@ -1,0 +1,19 @@
+using PokeSoulLinkBot.Core.Models;
+
+namespace PokeSoulLinkBot.Infrastructure.Persistence.Migrations;
+
+/// <summary>
+/// Represents the versioned root document persisted by the run store.
+/// </summary>
+internal sealed class RunStoreDocument
+{
+    /// <summary>
+    /// Gets or sets the persisted schema version.
+    /// </summary>
+    public int SchemaVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets the persisted runs.
+    /// </summary>
+    public List<SoulLinkRun>? Runs { get; set; } = new ();
+}

--- a/PokeSoulLinkBot/Persistence/Migrations/RunStoreMigrationPipeline.cs
+++ b/PokeSoulLinkBot/Persistence/Migrations/RunStoreMigrationPipeline.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+
+namespace PokeSoulLinkBot.Infrastructure.Persistence.Migrations;
+
+/// <summary>
+/// Applies ordered migrations to persisted run-store documents.
+/// </summary>
+internal sealed class RunStoreMigrationPipeline
+{
+    /// <summary>
+    /// The schema version written by the current application.
+    /// </summary>
+    public const int CurrentSchemaVersion = 1;
+
+    private readonly IReadOnlyDictionary<int, IRunStoreMigration> migrations;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RunStoreMigrationPipeline"/> class.
+    /// </summary>
+    public RunStoreMigrationPipeline()
+    {
+        IRunStoreMigration[] knownMigrations =
+        {
+            new LegacyRunStoreMigration(),
+        };
+
+        this.migrations = knownMigrations.ToDictionary(migration => migration.SourceVersion);
+    }
+
+    /// <summary>
+    /// Migrates a document to <see cref="CurrentSchemaVersion"/>.
+    /// </summary>
+    /// <param name="document">The document to migrate.</param>
+    /// <returns>The current document.</returns>
+    /// <exception cref="JsonException">
+    /// Thrown when the version is invalid or has no migration path.
+    /// </exception>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when the document is newer than this application supports.
+    /// </exception>
+    public RunStoreDocument Migrate(RunStoreDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        if (document.SchemaVersion > CurrentSchemaVersion)
+        {
+            throw new NotSupportedException(
+                $"Run-store schema version {document.SchemaVersion} is newer than supported version {CurrentSchemaVersion}.");
+        }
+
+        if (document.SchemaVersion < 0)
+        {
+            throw new JsonException($"Unsupported run-store schema version {document.SchemaVersion}.");
+        }
+
+        RunStoreDocument currentDocument = document;
+        while (currentDocument.SchemaVersion < CurrentSchemaVersion)
+        {
+            if (!this.migrations.TryGetValue(currentDocument.SchemaVersion, out IRunStoreMigration? migration))
+            {
+                throw new JsonException(
+                    $"No run-store migration exists for schema version {currentDocument.SchemaVersion}.");
+            }
+
+            currentDocument = migration.Migrate(currentDocument);
+            if (currentDocument.SchemaVersion != migration.TargetVersion)
+            {
+                throw new JsonException(
+                    $"Run-store migration from version {migration.SourceVersion} did not produce version {migration.TargetVersion}.");
+            }
+        }
+
+        if (currentDocument.Runs is null)
+        {
+            throw new JsonException("The run-store document does not contain a runs collection.");
+        }
+
+        return currentDocument;
+    }
+}

--- a/PokeSoulLinkBot/Persistence/RunStore.cs
+++ b/PokeSoulLinkBot/Persistence/RunStore.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using PokeSoulLinkBot.Application.Interfaces;
 using PokeSoulLinkBot.Core.Models;
+using PokeSoulLinkBot.Infrastructure.Persistence.Migrations;
 
 namespace PokeSoulLinkBot.Infrastructure.Persistence;
 
@@ -14,6 +15,7 @@ public sealed class RunStore : IRunStore
     private readonly string filePath;
     private readonly string backupFilePath;
     private readonly JsonSerializerOptions jsonSerializerOptions;
+    private readonly RunStoreMigrationPipeline migrationPipeline;
     private readonly object stateLock = new object();
     private readonly object fileLock = new object();
     private readonly List<SoulLinkRun> runs;
@@ -31,8 +33,10 @@ public sealed class RunStore : IRunStore
         this.backupFilePath = filePath + BackupFileSuffix;
         this.jsonSerializerOptions = new JsonSerializerOptions
         {
+            PropertyNameCaseInsensitive = true,
             WriteIndented = true,
         };
+        this.migrationPipeline = new RunStoreMigrationPipeline();
 
         this.runs = this.LoadRuns();
     }
@@ -90,7 +94,12 @@ public sealed class RunStore : IRunStore
 
     private RunStoreSnapshot CreateSnapshotCore()
     {
-        string json = JsonSerializer.Serialize(this.runs, this.jsonSerializerOptions);
+        var document = new RunStoreDocument
+        {
+            SchemaVersion = RunStoreMigrationPipeline.CurrentSchemaVersion,
+            Runs = this.runs,
+        };
+        string json = JsonSerializer.Serialize(document, this.jsonSerializerOptions);
         return new RunStoreSnapshot(++this.nextSaveVersion, json);
     }
 
@@ -193,7 +202,9 @@ public sealed class RunStore : IRunStore
                 return false;
             }
 
-            persistedRuns = JsonSerializer.Deserialize<List<SoulLinkRun>>(json) ?? new List<SoulLinkRun>();
+            RunStoreDocument document = this.DeserializeDocument(json);
+            RunStoreDocument migratedDocument = this.migrationPipeline.Migrate(document);
+            persistedRuns = migratedDocument.Runs!;
             return true;
         }
         catch (JsonException)
@@ -204,6 +215,24 @@ public sealed class RunStore : IRunStore
         {
             return false;
         }
+    }
+
+    private RunStoreDocument DeserializeDocument(string json)
+    {
+        using JsonDocument parsedDocument = JsonDocument.Parse(json);
+
+        return parsedDocument.RootElement.ValueKind switch
+        {
+            JsonValueKind.Array => new RunStoreDocument
+            {
+                SchemaVersion = 0,
+                Runs = JsonSerializer.Deserialize<List<SoulLinkRun>>(json, this.jsonSerializerOptions),
+            },
+            JsonValueKind.Object => JsonSerializer.Deserialize<RunStoreDocument>(
+                json,
+                this.jsonSerializerOptions) ?? throw new JsonException("The run-store document is empty."),
+            _ => throw new JsonException("The run-store root must be an object or an array."),
+        };
     }
 
     private void WriteAllText(string path, string content)

--- a/docs/run-data-migrations.md
+++ b/docs/run-data-migrations.md
@@ -1,0 +1,38 @@
+# Run-Datenversionen und Migrationen
+
+`RunStore` persistiert Runs als versioniertes Root-Dokument:
+
+```json
+{
+  "SchemaVersion": 1,
+  "Runs": []
+}
+```
+
+Die aktuelle Version steht in `RunStoreMigrationPipeline.CurrentSchemaVersion`. Neue Dateien werden immer mit dieser Version geschrieben.
+
+## Abwaertskompatibilitaet
+
+Dateien aus der Zeit vor Schema-Version 1 bestanden aus einem nackten JSON-Array:
+
+```json
+[
+  {
+    "Id": "00000000-0000-0000-0000-000000000000",
+    "GuildId": "guild-1"
+  }
+]
+```
+
+`RunStore.DeserializeDocument` erkennt dieses Format, ordnet ihm intern Version 0 zu und uebergibt es an die Migrations-Pipeline. Beim naechsten Speichern wird das aktuelle versionierte Format geschrieben. Die bestehende Backup-Datei bleibt dabei Teil des atomaren Speicherablaufs.
+
+## Eine neue Version hinzufuegen
+
+1. Das neue persistierte Modell abwaertskompatibel deserialisierbar gestalten oder ein separates Zwischenmodell einfuehren.
+2. Eine Implementierung von `IRunStoreMigration` unter `PokeSoulLinkBot/Persistence/Migrations` anlegen.
+3. `SourceVersion` und `TargetVersion` als genau einen aufeinanderfolgenden Schritt definieren.
+4. Die Migration in `RunStoreMigrationPipeline` registrieren.
+5. `CurrentSchemaVersion` erst danach auf die neue Zielversion erhoehen.
+6. Tests fuer das bisherige Format, den Migrationsschritt und das aktuelle Ausgabeformat ergaenzen.
+
+Migrationen duerfen keine Guilds, Runs oder fachlichen Eintraege stillschweigend verwerfen. Eine unbekannte, negative oder neuere Version wird abgelehnt, damit eine aeltere Bot-Version keine Daten mit einem nicht verstandenen Schema ueberschreibt.


### PR DESCRIPTION
Ticket: https://github.com/mpiechot/PokemonSoulLinkDiscord/issues/28

## Summary
- persist run data in a versioned root document with `SchemaVersion` and `Runs`
- load legacy unversioned JSON arrays through an explicit version 0 -> 1 migration
- add an ordered migration pipeline and documentation for future schema versions
- refuse newer unsupported schemas so an older bot cannot overwrite them

## Data impact
Existing `runs.json` arrays remain readable. They are written in the current versioned format on the next save while the existing atomic backup behavior is preserved.

## Verification
- TDD red/green coverage for legacy arrays, current documents, versioned output, and newer unsupported schemas
- `dotnet test PokeSoulLinkBot.Tests/PokeSoulLinkBot.Tests.csproj --no-restore --filter "FullyQualifiedName~RunStoreTests" ...` (7 passed)
- `dotnet build PokeSoulLinkBot/PokeSoulLinkBot.csproj --no-restore --no-incremental --verbosity minimal -p:UseAppHost=false -p:UseSharedCompilation=false -p:OutputPath=../artifacts/build/sg-003/`
- `dotnet test PokeSoulLinkBot.Tests/PokeSoulLinkBot.Tests.csproj --no-restore --verbosity minimal -p:UseAppHost=false -p:UseSharedCompilation=false -p:OutputPath=../artifacts/test/sg-003-full/` (122 passed)
- `git diff --cached --check`
- all seven changed text files report `w/crlf`

The build still reports the pre-existing SA0001 project-configuration warning; this PR introduces no analyzer warning.