### PR TITLE
Fix inconsistent /team, /use, and /status team state

### DIFF
--- a/PokeSoulLinkBot.Tests/EmbedFactoryStatusTests.cs
+++ b/PokeSoulLinkBot.Tests/EmbedFactoryStatusTests.cs
@@ -62,6 +62,24 @@ public sealed class EmbedFactoryStatusTests
     }
 
     [Fact]
+    public void CreateTeamAndStatusMessages_ShouldShowCurrentTeamPositionsInSlotOrder()
+    {
+        var run = CreateRun();
+        var firstSlotRoute = CreateLinkGroup("102", true, "Pichu");
+        var secondSlotRoute = CreateLinkGroup("101", true, "Bisasam");
+        run.LinkGroups.AddRange(new[] { firstSlotRoute, secondSlotRoute });
+        run.ActiveLinks[0] = firstSlotRoute;
+        run.ActiveLinks[1] = secondSlotRoute;
+        var embedFactory = new EmbedFactory();
+
+        var teamMessage = embedFactory.CreateTeamMessage(run);
+        var statusMessage = embedFactory.CreateStatusMessage(run);
+
+        AssertCurrentTeamPositions(teamMessage);
+        AssertCurrentTeamPositions(statusMessage);
+    }
+
+    [Fact]
     public void CreateDeathRegisteredEmbed_ShouldIncludeReasonAndCausingPlayer()
     {
         var linkGroup = CreateLinkGroup("101", false, "Bisasam");
@@ -261,5 +279,14 @@ public sealed class EmbedFactoryStatusTests
                 },
             },
         };
+    }
+
+    private static void AssertCurrentTeamPositions(string message)
+    {
+        Assert.Contains("1: 102", message, StringComparison.Ordinal);
+        Assert.Contains("2: 101", message, StringComparison.Ordinal);
+        Assert.True(
+            message.IndexOf("1: 102", StringComparison.Ordinal) <
+            message.IndexOf("2: 101", StringComparison.Ordinal));
     }
 }

--- a/PokeSoulLinkBot.Tests/EmbedFactoryStatusTests.cs
+++ b/PokeSoulLinkBot.Tests/EmbedFactoryStatusTests.cs
@@ -48,6 +48,20 @@ public sealed class EmbedFactoryStatusTests
     }
 
     [Fact]
+    public void CreateTeamMessage_ShouldHideDeadActiveLinks()
+    {
+        var run = CreateRun();
+        var deadRoute = CreateLinkGroup("101", false, "Bisasam");
+        run.LinkGroups.Add(deadRoute);
+        run.ActiveLinks[0] = deadRoute;
+        var embedFactory = new EmbedFactory();
+
+        var message = embedFactory.CreateTeamMessage(run);
+
+        Assert.DoesNotContain("101", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CreateDeathRegisteredEmbed_ShouldIncludeReasonAndCausingPlayer()
     {
         var linkGroup = CreateLinkGroup("101", false, "Bisasam");

--- a/PokeSoulLinkBot.Tests/RunServiceCatchTests.cs
+++ b/PokeSoulLinkBot.Tests/RunServiceCatchTests.cs
@@ -384,6 +384,18 @@ public sealed class RunServiceCatchTests
     }
 
     [Fact]
+    public void UseRoute_ShouldRemoveRouteFromOtherTeamPositions()
+    {
+        var service = CreateServiceWithStartedRun();
+        service.RegisterCatch(GuildId, "101", 1, "marpie1", "Bisasam", Array.Empty<string>());
+
+        var activeRun = service.UseRoute(GuildId, "101", 2);
+
+        Assert.Null(activeRun.ActiveLinks[0]);
+        Assert.Equal("101", activeRun.ActiveLinks[1]?.Route);
+    }
+
+    [Fact]
     public void UseRoute_ShouldRejectDeadRoute()
     {
         var service = CreateServiceWithStartedRun();
@@ -393,6 +405,18 @@ public sealed class RunServiceCatchTests
         var exception = Assert.Throws<InvalidOperationException>(() => service.UseRoute(GuildId, "101", 1));
 
         Assert.Equal("Route '101' is dead and cannot be used.", exception.Message);
+    }
+
+    [Fact]
+    public void RegisterDeath_ShouldRemoveRouteFromActiveTeam()
+    {
+        var service = CreateServiceWithStartedRun();
+        service.RegisterCatch(GuildId, "101", 1, "marpie1", "Bisasam", Array.Empty<string>());
+
+        service.RegisterDeath(GuildId, "101", "Critical hit.", null, null);
+
+        var activeRun = service.GetActiveRun(GuildId);
+        Assert.DoesNotContain(activeRun.ActiveLinks, group => group?.Route == "101");
     }
 
     [Fact]

--- a/PokeSoulLinkBot.Tests/RunServiceCatchTests.cs
+++ b/PokeSoulLinkBot.Tests/RunServiceCatchTests.cs
@@ -396,6 +396,31 @@ public sealed class RunServiceCatchTests
     }
 
     [Fact]
+    public void UseRoute_ShouldSupportSixthPositionWhenPersistedSlotsWereShorter()
+    {
+        var service = CreateServiceWithStartedRun();
+        service.RegisterCatch(GuildId, "104", 1, "marpie1", "Kleinstein", Array.Empty<string>());
+        var activeRun = service.GetActiveRun(GuildId);
+        activeRun.ActiveLinks = activeRun.ActiveLinks.Take(5).ToArray();
+
+        var updatedRun = service.UseRoute(GuildId, "104", 6);
+
+        Assert.Equal(6, updatedRun.ActiveLinks.Length);
+        Assert.Equal("104", updatedRun.ActiveLinks[5]?.Route);
+    }
+
+    [Fact]
+    public void UseRoute_ShouldRejectZeroBasedPosition()
+    {
+        var service = CreateServiceWithStartedRun();
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            service.UseRoute(GuildId, "104", 0));
+
+        Assert.Equal("position", exception.ParamName);
+    }
+
+    [Fact]
     public void UseRoute_ShouldRejectDeadRoute()
     {
         var service = CreateServiceWithStartedRun();

--- a/PokeSoulLinkBot/Application/Services/RunService.cs
+++ b/PokeSoulLinkBot/Application/Services/RunService.cs
@@ -202,8 +202,17 @@ public sealed class RunService : IRunService
         {
             SoulLinkRun activeRun = this.GetActiveRun(guildId);
             LinkGroup linkGroup = this.GetAliveLinkGroup(activeRun, route);
+            var targetIndex = position - 1;
 
-            activeRun.ActiveLinks[position - 1] = linkGroup;
+            for (var index = 0; index < activeRun.ActiveLinks.Length; index++)
+            {
+                if (index != targetIndex && IsSameLinkGroup(activeRun.ActiveLinks[index], linkGroup))
+                {
+                    activeRun.ActiveLinks[index] = null;
+                }
+            }
+
+            activeRun.ActiveLinks[targetIndex] = linkGroup;
             this.runStore.Save();
 
             return activeRun;
@@ -288,6 +297,7 @@ public sealed class RunService : IRunService
                     : playerName.Trim();
             }
 
+            this.RemoveFromActiveLinks(activeRun, linkGroup);
             this.runStore.Save();
 
             return linkGroup;
@@ -361,6 +371,18 @@ public sealed class RunService : IRunService
         {
             return this.runStore.GetRunsForGuild(guildId);
         }
+    }
+
+    private static bool IsSameLinkGroup(LinkGroup? activeLink, LinkGroup linkGroup)
+    {
+        if (activeLink is null)
+        {
+            return false;
+        }
+
+        return ReferenceEquals(activeLink, linkGroup) ||
+            (activeLink.Id != Guid.Empty && activeLink.Id == linkGroup.Id) ||
+            string.Equals(activeLink.Route, linkGroup.Route, StringComparison.OrdinalIgnoreCase);
     }
 
     private LinkGroup CreateLinkGroup(SoulLinkRun run, string route)

--- a/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
+++ b/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
@@ -772,7 +772,10 @@ public sealed class EmbedFactory
     {
         var playerNames = run.Players.Select(player => player.UserName).ToList();
 
-        return this.CreateTableSections("Team", run.ActiveLinks, playerNames);
+        return this.CreateTableSections(
+            "Team",
+            run.ActiveLinks.Where(group => group is not null && group.IsAlive),
+            playerNames);
     }
 
     private string CreateRunHeader(string title, SoulLinkRun run)

--- a/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
+++ b/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
@@ -872,7 +872,7 @@ public sealed class EmbedFactory
         IReadOnlyList<string> playerNames,
         IReadOnlyDictionary<string, int>? teamPositions)
     {
-        const int routeWidth = 14;
+        var routeWidth = teamPositions is null ? 14 : 18;
         const int playerColumnWidth = 24;
         var groups = linkedGroups
             .Where(group => group != null)

--- a/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
+++ b/PokeSoulLinkBot/Bot/Factories/EmbedFactory.cs
@@ -740,6 +740,40 @@ public sealed class EmbedFactory
         return value ? "yes" : "no";
     }
 
+    private static IReadOnlyDictionary<string, int> CreateTeamPositions(SoulLinkRun run)
+    {
+        var positions = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        for (var index = 0; index < run.ActiveLinks.Length; index++)
+        {
+            LinkGroup? group = run.ActiveLinks[index];
+            if (group is not null && group.IsAlive && !positions.ContainsKey(group.Route))
+            {
+                positions[group.Route] = index + 1;
+            }
+        }
+
+        return positions;
+    }
+
+    private static int GetTeamPosition(
+        LinkGroup group,
+        IReadOnlyDictionary<string, int>? teamPositions)
+    {
+        return teamPositions is not null && teamPositions.TryGetValue(group.Route, out var position)
+            ? position
+            : int.MaxValue;
+    }
+
+    private static string FormatRoute(
+        LinkGroup group,
+        IReadOnlyDictionary<string, int>? teamPositions)
+    {
+        return teamPositions is not null && teamPositions.TryGetValue(group.Route, out var position)
+            ? $"{position}: {group.Route}"
+            : group.Route;
+    }
+
     private IReadOnlyList<string> CreateStatusBlocks(SoulLinkRun run)
     {
         ArgumentNullException.ThrowIfNull(run);
@@ -750,7 +784,11 @@ public sealed class EmbedFactory
         var playerNames = run.Players.Select(player => player.UserName).ToList();
         var blocks = new List<string>();
 
-        blocks.AddRange(this.CreateTableSections("⚔️ Current Team", currentTeam, playerNames));
+        blocks.AddRange(this.CreateTableSections(
+            "⚔️ Current Team",
+            currentTeam,
+            playerNames,
+            CreateTeamPositions(run)));
         blocks.AddRange(this.CreateTableSections("📦 Box", box, playerNames));
         blocks.AddRange(this.CreateTableSections("💀 Dead", run.LinkGroups.Where(group => !group.IsAlive), playerNames));
 
@@ -775,7 +813,8 @@ public sealed class EmbedFactory
         return this.CreateTableSections(
             "Team",
             run.ActiveLinks.Where(group => group is not null && group.IsAlive),
-            playerNames);
+            playerNames,
+            CreateTeamPositions(run));
     }
 
     private string CreateRunHeader(string title, SoulLinkRun run)
@@ -789,9 +828,10 @@ public sealed class EmbedFactory
     private IReadOnlyList<string> CreateTableSections(
         string title,
         IEnumerable<LinkGroup?> linkedGroups,
-        IReadOnlyList<string> playerNames)
+        IReadOnlyList<string> playerNames,
+        IReadOnlyDictionary<string, int>? teamPositions = null)
     {
-        var tableRows = this.BuildStringTableRows(linkedGroups, playerNames);
+        var tableRows = this.BuildStringTableRows(linkedGroups, playerNames, teamPositions);
         var headerRows = tableRows.Take(2).ToList();
         var rows = tableRows.Skip(2).ToList();
 
@@ -829,12 +869,18 @@ public sealed class EmbedFactory
 
     private IReadOnlyList<string> BuildStringTableRows(
         IEnumerable<LinkGroup?> linkedGroups,
-        IReadOnlyList<string> playerNames)
+        IReadOnlyList<string> playerNames,
+        IReadOnlyDictionary<string, int>? teamPositions)
     {
         const int routeWidth = 14;
         const int playerColumnWidth = 24;
+        var groups = linkedGroups
+            .Where(group => group != null)
+            .Select(group => group!)
+            .OrderBy(group => GetTeamPosition(group, teamPositions))
+            .ThenBy(group => group.Route, StringComparer.OrdinalIgnoreCase);
 
-        var header = $"{this.PadRight("Route", routeWidth)}" +
+        var header = $"{this.PadRight(teamPositions is null ? "Route" : "Pos. Route", routeWidth)}" +
                      string.Concat(playerNames.Select(player => this.PadRight(player, playerColumnWidth)));
 
         var separator = new string('-', routeWidth + (playerNames.Count * playerColumnWidth));
@@ -845,9 +891,9 @@ public sealed class EmbedFactory
             separator,
         };
 
-        foreach (var group in linkedGroups.Where(group => group != null).OrderBy(group => group!.Route))
+        foreach (var group in groups)
         {
-            var row = this.PadRight(group!.Route, routeWidth);
+            var row = this.PadRight(FormatRoute(group, teamPositions), routeWidth);
 
             foreach (var player in playerNames)
             {

--- a/PokeSoulLinkBot/Core/Models/SoulLinkRun.cs
+++ b/PokeSoulLinkBot/Core/Models/SoulLinkRun.cs
@@ -7,6 +7,8 @@ namespace PokeSoulLinkBot.Core.Models;
 /// </summary>
 public sealed class SoulLinkRun
 {
+    private LinkGroup?[] activeLinks = new LinkGroup?[6];
+
     /// <summary>
     /// Gets or sets the unique identifier of the run.
     /// </summary>
@@ -56,7 +58,18 @@ public sealed class SoulLinkRun
     /// Gets or sets the collection of active link groups.
     /// </summary>
     [JsonPropertyName("activeLinks")]
-    public LinkGroup?[] ActiveLinks { get; set; } = new LinkGroup?[6];
+    public LinkGroup?[] ActiveLinks
+    {
+        get => this.activeLinks;
+        set
+        {
+            this.activeLinks = new LinkGroup?[6];
+            if (value is not null)
+            {
+                Array.Copy(value, this.activeLinks, Math.Min(value.Length, this.activeLinks.Length));
+            }
+        }
+    }
 
     /// <summary>
     /// Gets or sets the completed arenas for this run.


### PR DESCRIPTION
Ticket: https://github.com/mpiechot/PokemonSoulLinkDiscord/issues/62

## Summary

- prevent `/use` from placing the same link group in multiple active team slots
- normalize persisted `ActiveLinks` data to six slots so `/use <route> 6` remains valid
- remove a route from active team slots when `/death` marks its link group dead
- hide dead active links from `/team` and the team output returned by `/use`
- include the active team slot index in `/team` and `/status` output
- sort Current Team rows by slot position instead of route name
- keep position `0` invalid; user-facing positions are `1` through `6`
- add regression tests for duplicate slots, short persisted slot arrays, dead team output, and slot ordering

## Root cause

`/use` overwrote only the requested slot, while `/death` left the dead link group referenced by `ActiveLinks`. The team presentation rendered all active references without checking `IsAlive`, so the commands could expose stale state. Older persisted runs could also contain fewer than six active slots, causing position 6 to throw an array-bounds exception. Current Team rows were also sorted alphabetically by route and did not expose their slot index.

## Verification

- targeted regression tests: passed
- `dotnet build PokeSoulLinkBot/PokeSoulLinkBot.csproj --no-restore --no-incremental --verbosity minimal -p:UseAppHost=false -p:UseSharedCompilation=false`
- `dotnet test PokeSoulLinkBot.Tests/PokeSoulLinkBot.Tests.csproj --no-restore --verbosity minimal` (124 passed)
- `git diff --cached --check`
- changed files report `w/crlf`