### PR TITLE
Add safe SoulLink runtime configuration

### DIFF
--- a/PokeSoulLinkBot.Tests/BotHostTests.cs
+++ b/PokeSoulLinkBot.Tests/BotHostTests.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using PokeSoulLinkBot.Bot.Handlers;
 using PokeSoulLinkBot.Bot.Hosting;
+using PokeSoulLinkBot.Core.Configuration;
 using Xunit;
 
 namespace PokeSoulLinkBot.Tests;
@@ -18,5 +20,10 @@ public sealed class BotHostTests
             host.Services.GetServices<IHostedService>(),
             hostedService => hostedService is DiscordBotHostedService);
         Assert.NotNull(host.Services.GetRequiredService<SlashCommandRouter>());
+
+        SoulLinkOptions options = host.Services.GetRequiredService<IOptions<SoulLinkOptions>>().Value;
+        Assert.True(options.EnableReadTracking);
+        Assert.False(options.EnableRemoteWrites);
+        Assert.False(options.EnableAutoTeamSync);
     }
 }

--- a/PokeSoulLinkBot.Tests/SoulLinkOptionsTests.cs
+++ b/PokeSoulLinkBot.Tests/SoulLinkOptionsTests.cs
@@ -1,0 +1,31 @@
+using PokeSoulLinkBot.Core.Configuration;
+using Xunit;
+
+namespace PokeSoulLinkBot.Tests;
+
+public sealed class SoulLinkOptionsTests
+{
+    [Fact]
+    public void Defaults_KeepRemoteWritesAndAutoTeamSyncDisabled()
+    {
+        var options = new SoulLinkOptions();
+
+        Assert.True(options.Enabled);
+        Assert.True(options.EnableDiscordEvents);
+        Assert.True(options.EnableReadTracking);
+        Assert.False(options.EnableRemoteWrites);
+        Assert.False(options.EnableAutoTeamSync);
+        Assert.True(options.IsValid());
+    }
+
+    [Fact]
+    public void AutoTeamSyncWithoutRemoteWrites_IsInvalid()
+    {
+        var options = new SoulLinkOptions
+        {
+            EnableAutoTeamSync = true,
+        };
+
+        Assert.False(options.IsValid());
+    }
+}

--- a/PokeSoulLinkBot/Bot/Hosting/BotHost.cs
+++ b/PokeSoulLinkBot/Bot/Hosting/BotHost.cs
@@ -11,6 +11,7 @@ using PokeSoulLinkBot.Bot.Handlers;
 using PokeSoulLinkBot.Bot.Presentation;
 using PokeSoulLinkBot.Bot.Registration;
 using PokeSoulLinkBot.Bot.Services;
+using PokeSoulLinkBot.Core.Configuration;
 using PokeSoulLinkBot.Infrastructure.Persistence;
 
 namespace PokeSoulLinkBot.Bot.Hosting;
@@ -51,6 +52,13 @@ public static class BotHost
 
     private static void RegisterServices(IServiceCollection services, IConfiguration configuration)
     {
+        services.AddOptions<SoulLinkOptions>()
+            .Bind(configuration.GetSection(SoulLinkOptions.SectionName))
+            .Validate(
+                options => options.IsValid(),
+                "EnableAutoTeamSync requires EnableRemoteWrites to be enabled.")
+            .ValidateOnStart();
+
         services.AddSingleton<DiscordSocketClient>(_ => new DiscordSocketClient(new DiscordSocketConfig
         {
             GatewayIntents = GatewayIntents.Guilds,

--- a/PokeSoulLinkBot/Bot/Hosting/DiscordBotHostedService.cs
+++ b/PokeSoulLinkBot/Bot/Hosting/DiscordBotHostedService.cs
@@ -2,10 +2,12 @@ using Discord;
 using Discord.WebSocket;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using PokeSoulLinkBot.Application.Interfaces;
 using PokeSoulLinkBot.Application.Services;
 using PokeSoulLinkBot.Bot.Handlers;
 using PokeSoulLinkBot.Bot.Registration;
+using PokeSoulLinkBot.Core.Configuration;
 using Serilog;
 using Serilog.Events;
 
@@ -25,6 +27,7 @@ public sealed class DiscordBotHostedService : IHostedService
     private readonly PokemonDataCacheStore pokemonDataCacheStore;
     private readonly PokeApiPokemonNameResolver pokemonNameResolver;
     private readonly IBotDiagnosticsService diagnosticsService;
+    private readonly IOptions<SoulLinkOptions> options;
     private ReadyStartupTaskRunner? readyStartupTaskRunner;
 
     /// <summary>
@@ -39,7 +42,8 @@ public sealed class DiscordBotHostedService : IHostedService
         PokemonDbArenaInfoService arenaInfoService,
         PokemonDataCacheStore pokemonDataCacheStore,
         PokeApiPokemonNameResolver pokemonNameResolver,
-        IBotDiagnosticsService diagnosticsService)
+        IBotDiagnosticsService diagnosticsService,
+        IOptions<SoulLinkOptions> options)
     {
         this.client = client ?? throw new ArgumentNullException(nameof(client));
         this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
@@ -54,11 +58,24 @@ public sealed class DiscordBotHostedService : IHostedService
         this.pokemonNameResolver = pokemonNameResolver ??
             throw new ArgumentNullException(nameof(pokemonNameResolver));
         this.diagnosticsService = diagnosticsService ?? throw new ArgumentNullException(nameof(diagnosticsService));
+        this.options = options ?? throw new ArgumentNullException(nameof(options));
     }
 
     /// <inheritdoc />
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        SoulLinkOptions configuredOptions = this.options.Value;
+        if (!configuredOptions.Enabled || !configuredOptions.EnableDiscordEvents)
+        {
+            Log.Information(
+                "Discord event handling is disabled by configuration. Read tracking: {ReadTrackingEnabled}; " +
+                "remote writes: {RemoteWritesEnabled}; auto team sync: {AutoTeamSyncEnabled}.",
+                configuredOptions.EnableReadTracking,
+                configuredOptions.EnableRemoteWrites,
+                configuredOptions.EnableAutoTeamSync);
+            return;
+        }
+
         string token = this.configuration["DISCORD_BOT_TOKEN"] ?? string.Empty;
         if (string.IsNullOrWhiteSpace(token))
         {

--- a/PokeSoulLinkBot/Core/Configuration/SoulLinkOptions.cs
+++ b/PokeSoulLinkBot/Core/Configuration/SoulLinkOptions.cs
@@ -1,0 +1,61 @@
+namespace PokeSoulLinkBot.Core.Configuration;
+
+/// <summary>
+/// Runtime switches and paths for the SoulLink host.
+/// </summary>
+public sealed class SoulLinkOptions
+{
+    /// <summary>
+    /// The configuration section name.
+    /// </summary>
+    public const string SectionName = "SoulLink";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the SoulLink host is enabled.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Discord event handling is enabled.
+    /// </summary>
+    public bool EnableDiscordEvents { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether read-only game tracking is enabled.
+    /// </summary>
+    public bool EnableReadTracking { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether remote game writes are enabled.
+    /// </summary>
+    public bool EnableRemoteWrites { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether automatic team synchronization is enabled.
+    /// </summary>
+    public bool EnableAutoTeamSync { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional run persistence path.
+    /// </summary>
+    public string? PersistencePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional game data cache path.
+    /// </summary>
+    public string? GameDataCachePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional Pokémon data cache path.
+    /// </summary>
+    public string? PokemonDataCachePath { get; set; }
+
+    /// <summary>
+    /// Validates relationships between feature flags.
+    /// </summary>
+    /// <returns><see langword="true"/> when the options are consistent.</returns>
+    public bool IsValid()
+    {
+        return !this.EnableAutoTeamSync || this.EnableRemoteWrites;
+    }
+}

--- a/PokeSoulLinkBot/appsettings.example.json
+++ b/PokeSoulLinkBot/appsettings.example.json
@@ -1,0 +1,9 @@
+{
+  "SoulLink": {
+    "Enabled": true,
+    "EnableDiscordEvents": true,
+    "EnableReadTracking": true,
+    "EnableRemoteWrites": false,
+    "EnableAutoTeamSync": false
+  }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,20 @@
+# Runtime configuration
+
+The host reads the `SoulLink` section from `appsettings.json`, environment
+variables, and optional user secrets. The checked-in defaults are safe for a
+fresh installation:
+
+- read-only tracking is enabled;
+- Discord event handling is enabled;
+- remote game writes are disabled;
+- automatic team synchronization is disabled.
+
+The Discord token is supplied through the `DISCORD_BOT_TOKEN` environment
+variable or user secrets. It is intentionally not part of `SoulLinkOptions`,
+configuration files, diagnostics, or exported run data, and the host never
+logs the token value.
+
+`EnableAutoTeamSync` requires `EnableRemoteWrites`; inconsistent combinations
+are rejected during host startup. Explicitly enabling remote writes remains a
+deliberate operator decision and does not activate an implementation that has
+not been added yet.


### PR DESCRIPTION
Ticket: https://github.com/mpiechot/PokemonSoulLinkDiscord/issues/70

## Summary
- add typed SoulLinkOptions with explicit read/write and synchronization flags
- validate unsafe flag combinations during host startup
- provide safe example configuration and document secret handling
- keep remote writes and automatic team synchronization disabled by default

## Verification
- dotnet test PokeSoulLinkBot.Tests/PokeSoulLinkBot.Tests.csproj --no-restore --verbosity minimal