### PR TITLE
Harden host failure and shutdown boundaries

### DIFF
--- a/PokeSoulLinkBot/Bot/Hosting/BotHost.cs
+++ b/PokeSoulLinkBot/Bot/Hosting/BotHost.cs
@@ -52,6 +52,9 @@ public static class BotHost
 
     private static void RegisterServices(IServiceCollection services, IConfiguration configuration)
     {
+        services.Configure<HostOptions>(options =>
+            options.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.StopHost);
+
         services.AddOptions<SoulLinkOptions>()
             .Bind(configuration.GetSection(SoulLinkOptions.SectionName))
             .Validate(

--- a/PokeSoulLinkBot/Bot/Hosting/DiscordBotHostedService.cs
+++ b/PokeSoulLinkBot/Bot/Hosting/DiscordBotHostedService.cs
@@ -29,6 +29,7 @@ public sealed class DiscordBotHostedService : IHostedService
     private readonly IBotDiagnosticsService diagnosticsService;
     private readonly IOptions<SoulLinkOptions> options;
     private ReadyStartupTaskRunner? readyStartupTaskRunner;
+    private bool eventHandlersAttached;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DiscordBotHostedService"/> class.
@@ -64,6 +65,7 @@ public sealed class DiscordBotHostedService : IHostedService
     /// <inheritdoc />
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         SoulLinkOptions configuredOptions = this.options.Value;
         if (!configuredOptions.Enabled || !configuredOptions.EnableDiscordEvents)
         {
@@ -87,25 +89,54 @@ public sealed class DiscordBotHostedService : IHostedService
         this.client.Ready += this.readyStartupTaskRunner.HandleReadyAsync;
         this.client.SlashCommandExecuted += this.slashCommandRouter.HandleAsync;
         this.client.AutocompleteExecuted += this.slashCommandRouter.HandleAutocompleteAsync;
+        this.eventHandlersAttached = true;
 
-        Log.Information("Starting PokeSoulLinkBot.");
-        await this.client.LoginAsync(TokenType.Bot, token);
-        Log.Information("Discord login completed.");
-        await this.client.StartAsync();
-        Log.Information("Discord client started.");
+        try
+        {
+            Log.Information("Starting PokeSoulLinkBot.");
+            await this.client.LoginAsync(TokenType.Bot, token);
+            Log.Information("Discord login completed.");
+            await this.client.StartAsync();
+            Log.Information("Discord client started.");
+        }
+        catch (Exception exception)
+        {
+            Log.Fatal(exception, "Discord client startup failed; the host will terminate for external recovery.");
+            this.RecordExceptionSafely("Fatal", "DiscordStartup", "Discord client startup failed.", exception);
+            this.DetachEventHandlers();
+            throw;
+        }
     }
 
     /// <inheritdoc />
     public async Task StopAsync(CancellationToken cancellationToken)
     {
-        if (this.client.ConnectionState is ConnectionState.Connected or ConnectionState.Connecting)
+        this.DetachEventHandlers();
+
+        try
         {
-            await this.client.StopAsync();
+            if (this.client.ConnectionState is ConnectionState.Connected or ConnectionState.Connecting)
+            {
+                await this.client.StopAsync();
+            }
+        }
+        catch (Exception exception)
+        {
+            Log.Error(exception, "Discord client stop failed; continuing shutdown.");
+            this.RecordExceptionSafely("Error", "DiscordShutdown", "Discord client stop failed.", exception);
         }
 
-        if (this.client.LoginState is LoginState.LoggedIn or LoginState.LoggingIn)
+        try
         {
-            await this.client.LogoutAsync();
+            if (this.client.LoginState is LoginState.LoggedIn or LoginState.LoggingIn)
+            {
+                await this.client.LogoutAsync();
+            }
+        }
+        catch (Exception exception)
+        {
+            Log.Error(exception, "Discord logout failed; continuing shutdown.");
+            this.RecordExceptionSafely("Error", "DiscordShutdown", "Discord logout failed.", exception);
         }
     }
 
@@ -193,7 +224,7 @@ public sealed class DiscordBotHostedService : IHostedService
         catch (Exception exception)
         {
             Log.Error(exception, "Ready startup failed.");
-            this.diagnosticsService.RecordException("Error", "ReadyStartup", "Ready startup failed.", exception);
+            this.RecordExceptionSafely("Error", "ReadyStartup", "Ready startup failed.", exception);
         }
     }
 
@@ -209,7 +240,7 @@ public sealed class DiscordBotHostedService : IHostedService
         catch (Exception exception)
         {
             Log.Warning(exception, "Pokemon data cache warmup failed.");
-            this.diagnosticsService.RecordException(
+            this.RecordExceptionSafely(
                 "Warning",
                 "PokemonDataWarmup",
                 "Pokemon data cache warmup failed.",
@@ -269,13 +300,55 @@ public sealed class DiscordBotHostedService : IHostedService
         if (logMessage.Exception is not null)
         {
             Log.Write(level, logMessage.Exception, "Discord {Source}: {Message}", logMessage.Source, message);
-            this.RecordDiscordDiagnostic(logMessage, message);
+            this.RecordDiscordDiagnosticSafely(logMessage, message);
             return Task.CompletedTask;
         }
 
         Log.Write(level, "Discord {Source}: {Message}", logMessage.Source, message);
-        this.RecordDiscordDiagnostic(logMessage, message);
+        this.RecordDiscordDiagnosticSafely(logMessage, message);
         return Task.CompletedTask;
+    }
+
+    private void DetachEventHandlers()
+    {
+        if (!this.eventHandlersAttached)
+        {
+            return;
+        }
+
+        this.client.Log -= this.OnLogAsync;
+        if (this.readyStartupTaskRunner is not null)
+        {
+            this.client.Ready -= this.readyStartupTaskRunner.HandleReadyAsync;
+        }
+
+        this.client.SlashCommandExecuted -= this.slashCommandRouter.HandleAsync;
+        this.client.AutocompleteExecuted -= this.slashCommandRouter.HandleAutocompleteAsync;
+        this.eventHandlersAttached = false;
+    }
+
+    private void RecordDiscordDiagnosticSafely(LogMessage logMessage, string message)
+    {
+        try
+        {
+            this.RecordDiscordDiagnostic(logMessage, message);
+        }
+        catch (Exception exception)
+        {
+            Log.Error(exception, "Discord diagnostic recording failed; event handling will continue.");
+        }
+    }
+
+    private void RecordExceptionSafely(string severity, string source, string message, Exception exception)
+    {
+        try
+        {
+            this.diagnosticsService.RecordException(severity, source, message, exception);
+        }
+        catch (Exception diagnosticException)
+        {
+            Log.Error(diagnosticException, "Diagnostic recording failed for {Source}.", source);
+        }
     }
 
     private void RecordDiscordDiagnostic(LogMessage logMessage, string message)

--- a/deploy/pokesoullinkbot.service
+++ b/deploy/pokesoullinkbot.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Pokemon SoulLink Discord bot
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+WorkingDirectory=/opt/pokesoullinkbot
+ExecStart=/usr/bin/dotnet /opt/pokesoullinkbot/PokeSoulLinkBot.dll
+EnvironmentFile=/etc/pokesoullinkbot.env
+Restart=on-failure
+RestartSec=5
+KillSignal=SIGINT
+TimeoutStopSec=30
+SyslogIdentifier=pokesoullinkbot
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -1,0 +1,22 @@
+# Reliability and recovery
+
+The process has three explicit failure boundaries:
+
+1. Discord client startup failures are logged as fatal, diagnostics are
+   recorded when possible, event handlers are detached, and the exception is
+   rethrown. This keeps an unrecoverable process failure visible to the host
+   supervisor instead of leaving a half-started bot running.
+2. Discord log events, command routing, ready-time initialization, and cache
+   warmup are isolated task boundaries. A failure is logged and recorded, but
+   does not escape into the Discord gateway callback or stop unrelated work.
+3. Shutdown attempts client stop and logout independently. A cleanup failure is
+   logged and recorded while the remaining shutdown steps still run.
+
+The service file in `deploy/pokesoullinkbot.service` is a deployment recipe for
+systemd. `Restart=on-failure` restarts the process after an unrecoverable host
+failure; it does not hide the original exception from the logs.
+
+State-changing operations remain behind the application services and their
+persistence boundary. A command is acknowledged by the existing router before
+its result is reported, and the host does not introduce an in-memory retry that
+could apply a state change twice.


### PR DESCRIPTION
Ticket: https://github.com/mpiechot/PokemonSoulLinkDiscord/issues/69

## Summary
- isolate Discord startup, event diagnostics, ready initialization, and cache warmup failures
- detach handlers after failed startup and perform shutdown cleanup independently
- make hosted-service exception behavior explicit and add a systemd restart recipe

## Verification
- dotnet test PokeSoulLinkBot.Tests/PokeSoulLinkBot.Tests.csproj --no-restore --verbosity minimal