### PR TITLE
Add source-bound Pokemon Ruby compatibility adapter

### DIFF
--- a/PokeSoulLinkBot.Tests/BotHostTests.cs
+++ b/PokeSoulLinkBot.Tests/BotHostTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using PokeSoulLinkBot.Bot.Handlers;
 using PokeSoulLinkBot.Bot.Hosting;
 using PokeSoulLinkBot.Core.Configuration;
+using PokeSoulLinkBot.Core.GameIntegration;
 using Xunit;
 
 namespace PokeSoulLinkBot.Tests;
@@ -20,6 +21,7 @@ public sealed class BotHostTests
             host.Services.GetServices<IHostedService>(),
             hostedService => hostedService is DiscordBotHostedService);
         Assert.NotNull(host.Services.GetRequiredService<SlashCommandRouter>());
+        Assert.NotNull(host.Services.GetRequiredService<IRomCompatibilityAdapter>());
 
         SoulLinkOptions options = host.Services.GetRequiredService<IOptions<SoulLinkOptions>>().Value;
         Assert.True(options.EnableReadTracking);

--- a/PokeSoulLinkBot.Tests/PokemonRubyCompatibilityAdapterTests.cs
+++ b/PokeSoulLinkBot.Tests/PokemonRubyCompatibilityAdapterTests.cs
@@ -1,0 +1,62 @@
+using PokeSoulLinkBot.Core.GameIntegration;
+using Xunit;
+
+namespace PokeSoulLinkBot.Tests;
+
+public sealed class PokemonRubyCompatibilityAdapterTests
+{
+    [Fact]
+    public void Resolve_RecognizesGermanRubyWithoutUsingCrc32()
+    {
+        byte[] header = CreateHeader("POKEMON RUBY", "AXVD", revision: 1);
+        header[0xB0] = 0xFF;
+        header[0xB1] = 0xFF;
+
+        RomCompatibilityResult result = new PokemonRubyCompatibilityAdapter().Resolve(header);
+
+        Assert.Equal(RomSupportStatus.DiagnosticOnly, result.Status);
+        Assert.Equal("AXVD", result.Identity?.GameCode);
+        Assert.Equal(0x03004360u, result.MemoryLayout?.PlayerPartyAddress);
+        Assert.Contains("CRC32", result.Diagnostic, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Resolve_RejectsDifferentTitle()
+    {
+        byte[] header = CreateHeader("POKEMON SAPP", "AXPD", revision: 0);
+
+        RomCompatibilityResult result = new PokemonRubyCompatibilityAdapter().Resolve(header);
+
+        Assert.Equal(RomSupportStatus.Unsupported, result.Status);
+        Assert.Null(result.MemoryLayout);
+    }
+
+    [Fact]
+    public void Resolve_RecognizesRubyTitleButKeepsOtherVariantsDiagnosticOnly()
+    {
+        byte[] header = CreateHeader("POKEMON RUBY", "AXVE", revision: 0);
+
+        RomCompatibilityResult result = new PokemonRubyCompatibilityAdapter().Resolve(header);
+
+        Assert.Equal(RomSupportStatus.DiagnosticOnly, result.Status);
+        Assert.Null(result.MemoryLayout);
+        Assert.Contains("AXVD", result.Diagnostic, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static byte[] CreateHeader(string title, string gameCode, byte revision)
+    {
+        var header = new byte[0xC0];
+        WriteAscii(header, 0xA0, 12, title);
+        WriteAscii(header, 0xAC, 4, gameCode);
+        header[0xBC] = revision;
+        return header;
+    }
+
+    private static void WriteAscii(byte[] target, int offset, int length, string value)
+    {
+        for (int index = 0; index < Math.Min(length, value.Length); index++)
+        {
+            target[offset + index] = (byte)value[index];
+        }
+    }
+}

--- a/PokeSoulLinkBot/Bot/Hosting/BotHost.cs
+++ b/PokeSoulLinkBot/Bot/Hosting/BotHost.cs
@@ -12,6 +12,7 @@ using PokeSoulLinkBot.Bot.Presentation;
 using PokeSoulLinkBot.Bot.Registration;
 using PokeSoulLinkBot.Bot.Services;
 using PokeSoulLinkBot.Core.Configuration;
+using PokeSoulLinkBot.Core.GameIntegration;
 using PokeSoulLinkBot.Infrastructure.Persistence;
 
 namespace PokeSoulLinkBot.Bot.Hosting;
@@ -96,6 +97,7 @@ public static class BotHost
         services.AddSingleton<TeamCheckAnalyzer>();
         services.AddSingleton<IBotDiagnosticsService, BotDiagnosticsService>();
         services.AddSingleton<IBotHealthService, BotHealthService>();
+        services.AddSingleton<IRomCompatibilityAdapter, PokemonRubyCompatibilityAdapter>();
 
         services.AddSingleton<EmbedFactory>();
         services.AddSingleton(_ => new EmbedImageFactory(GetResourcesDirectoryPath()));

--- a/PokeSoulLinkBot/Core/GameIntegration/IRomCompatibilityAdapter.cs
+++ b/PokeSoulLinkBot/Core/GameIntegration/IRomCompatibilityAdapter.cs
@@ -1,0 +1,19 @@
+namespace PokeSoulLinkBot.Core.GameIntegration;
+
+/// <summary>
+/// Resolves a ROM header into an edition-specific compatibility profile.
+/// </summary>
+public interface IRomCompatibilityAdapter
+{
+    /// <summary>
+    /// Gets the stable adapter identifier.
+    /// </summary>
+    string AdapterId { get; }
+
+    /// <summary>
+    /// Evaluates the header without relying on a CRC32 value.
+    /// </summary>
+    /// <param name="romHeader">At least the first 0xBD bytes of the ROM.</param>
+    /// <returns>The compatibility result.</returns>
+    RomCompatibilityResult Resolve(ReadOnlySpan<byte> romHeader);
+}

--- a/PokeSoulLinkBot/Core/GameIntegration/PokemonRubyCompatibilityAdapter.cs
+++ b/PokeSoulLinkBot/Core/GameIntegration/PokemonRubyCompatibilityAdapter.cs
@@ -1,0 +1,73 @@
+using System.Text;
+
+namespace PokeSoulLinkBot.Core.GameIntegration;
+
+/// <summary>
+/// Identifies the German Pokémon Rubin target and its Ruby-family references.
+/// </summary>
+public sealed class PokemonRubyCompatibilityAdapter : IRomCompatibilityAdapter
+{
+    private const int GameTitleOffset = 0xA0;
+    private const int GameTitleLength = 12;
+    private const int GameCodeOffset = 0xAC;
+    private const int GameCodeLength = 4;
+    private const int RevisionOffset = 0xBC;
+    private const int MinimumHeaderLength = RevisionOffset + 1;
+    private const string ExpectedTitle = "POKEMON RUBY";
+    private const string GermanGameCode = "AXVD";
+
+    /// <inheritdoc />
+    public string AdapterId => "pokemon-ruby";
+
+    /// <inheritdoc />
+    public RomCompatibilityResult Resolve(ReadOnlySpan<byte> romHeader)
+    {
+        if (romHeader.Length < MinimumHeaderLength)
+        {
+            return new RomCompatibilityResult(
+                RomSupportStatus.Unsupported,
+                null,
+                null,
+                $"ROM header is too short; expected at least 0x{MinimumHeaderLength:X} bytes.");
+        }
+
+        string title = ReadAscii(romHeader.Slice(GameTitleOffset, GameTitleLength));
+        string gameCode = ReadAscii(romHeader.Slice(GameCodeOffset, GameCodeLength));
+        var identity = new RomIdentity(title, gameCode, romHeader[RevisionOffset]);
+
+        if (!string.Equals(title, ExpectedTitle, StringComparison.OrdinalIgnoreCase))
+        {
+            return new RomCompatibilityResult(
+                RomSupportStatus.Unsupported,
+                identity,
+                null,
+                "ROM title is not Pokémon Ruby.");
+        }
+
+        if (!string.Equals(gameCode, GermanGameCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return new RomCompatibilityResult(
+                RomSupportStatus.DiagnosticOnly,
+                identity,
+                null,
+                "Ruby title recognized, but this adapter currently targets the German AXVD profile.");
+        }
+
+        return new RomCompatibilityResult(
+            RomSupportStatus.DiagnosticOnly,
+            identity,
+            new RomMemoryLayoutReference(
+                "pokemon-ruby-party-reference",
+                0x03004360,
+                0x64,
+                6,
+                "reference-only; validate against an AXVD fixture before live polling",
+                "pret/pokeruby include/pokemon.h; reference address documented by Bulbapedia"),
+            "German Pokémon Ruby AXVD recognized without CRC32; live memory polling remains fixture-gated.");
+    }
+
+    private static string ReadAscii(ReadOnlySpan<byte> bytes)
+    {
+        return Encoding.ASCII.GetString(bytes).TrimEnd('\0', ' ');
+    }
+}

--- a/PokeSoulLinkBot/Core/GameIntegration/RomCompatibilityResult.cs
+++ b/PokeSoulLinkBot/Core/GameIntegration/RomCompatibilityResult.cs
@@ -1,0 +1,42 @@
+namespace PokeSoulLinkBot.Core.GameIntegration;
+
+/// <summary>
+/// Result of evaluating a ROM header against an adapter.
+/// </summary>
+public sealed record RomCompatibilityResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RomCompatibilityResult"/> class.
+    /// </summary>
+    public RomCompatibilityResult(
+        RomSupportStatus status,
+        RomIdentity? identity,
+        RomMemoryLayoutReference? memoryLayout,
+        string diagnostic)
+    {
+        this.Status = status;
+        this.Identity = identity;
+        this.MemoryLayout = memoryLayout;
+        this.Diagnostic = diagnostic;
+    }
+
+    /// <summary>
+    /// Gets the support status.
+    /// </summary>
+    public RomSupportStatus Status { get; }
+
+    /// <summary>
+    /// Gets the parsed identity, when the header was long enough.
+    /// </summary>
+    public RomIdentity? Identity { get; }
+
+    /// <summary>
+    /// Gets the layout reference, when one is available.
+    /// </summary>
+    public RomMemoryLayoutReference? MemoryLayout { get; }
+
+    /// <summary>
+    /// Gets the diagnostic explanation.
+    /// </summary>
+    public string Diagnostic { get; }
+}

--- a/PokeSoulLinkBot/Core/GameIntegration/RomIdentity.cs
+++ b/PokeSoulLinkBot/Core/GameIntegration/RomIdentity.cs
@@ -1,0 +1,32 @@
+namespace PokeSoulLinkBot.Core.GameIntegration;
+
+/// <summary>
+/// Identifies a GBA ROM using header values that survive ROM randomization.
+/// </summary>
+public sealed record RomIdentity
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RomIdentity"/> class.
+    /// </summary>
+    public RomIdentity(string title, string gameCode, byte revision)
+    {
+        this.Title = title;
+        this.GameCode = gameCode;
+        this.Revision = revision;
+    }
+
+    /// <summary>
+    /// Gets the ROM title.
+    /// </summary>
+    public string Title { get; }
+
+    /// <summary>
+    /// Gets the four-character game code.
+    /// </summary>
+    public string GameCode { get; }
+
+    /// <summary>
+    /// Gets the ROM revision byte.
+    /// </summary>
+    public byte Revision { get; }
+}

--- a/PokeSoulLinkBot/Core/GameIntegration/RomMemoryLayoutReference.cs
+++ b/PokeSoulLinkBot/Core/GameIntegration/RomMemoryLayoutReference.cs
@@ -1,0 +1,56 @@
+namespace PokeSoulLinkBot.Core.GameIntegration;
+
+/// <summary>
+/// Documents a read-only memory layout reference and its validation state.
+/// </summary>
+public sealed record RomMemoryLayoutReference
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RomMemoryLayoutReference"/> class.
+    /// </summary>
+    public RomMemoryLayoutReference(
+        string name,
+        uint playerPartyAddress,
+        int partyEntrySize,
+        int partySize,
+        string validationState,
+        string source)
+    {
+        this.Name = name;
+        this.PlayerPartyAddress = playerPartyAddress;
+        this.PartyEntrySize = partyEntrySize;
+        this.PartySize = partySize;
+        this.ValidationState = validationState;
+        this.Source = source;
+    }
+
+    /// <summary>
+    /// Gets the profile name.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets the reference address of the player party.
+    /// </summary>
+    public uint PlayerPartyAddress { get; }
+
+    /// <summary>
+    /// Gets the size of one party entry.
+    /// </summary>
+    public int PartyEntrySize { get; }
+
+    /// <summary>
+    /// Gets the number of party entries.
+    /// </summary>
+    public int PartySize { get; }
+
+    /// <summary>
+    /// Gets the validation state.
+    /// </summary>
+    public string ValidationState { get; }
+
+    /// <summary>
+    /// Gets the source description.
+    /// </summary>
+    public string Source { get; }
+}

--- a/PokeSoulLinkBot/Core/GameIntegration/RomSupportStatus.cs
+++ b/PokeSoulLinkBot/Core/GameIntegration/RomSupportStatus.cs
@@ -1,0 +1,11 @@
+namespace PokeSoulLinkBot.Core.GameIntegration;
+
+/// <summary>
+/// Describes how far a ROM adapter can safely proceed.
+/// </summary>
+public enum RomSupportStatus
+{
+    Unsupported,
+    DiagnosticOnly,
+    Supported,
+}

--- a/docs/game-integration-pokemon-ruby.md
+++ b/docs/game-integration-pokemon-ruby.md
@@ -1,0 +1,29 @@
+# Pokémon Ruby memory compatibility
+
+The first game adapter recognizes the German ROM shown in the project
+requirements:
+
+- title: `POKEMON RUBY`;
+- game code: `AXVD`;
+- revision: read from the GBA header;
+- CRC32: deliberately ignored, because a randomized ROM changes it.
+
+The adapter is header-based and does not write RAM. It returns a diagnostic-only
+profile for `AXVD` until a captured memory fixture validates the live address.
+That keeps a randomized ROM recognizable without pretending that an address
+from another revision or language is already proven for the target cartridge.
+
+The structural reference comes from the [pret/pokeruby Pokémon header](https://github.com/pret/pokeruby/blob/master/include/pokemon.h):
+
+- `BoxPokemon` is `0x50` bytes;
+- a party `Pokemon` is `0x64` bytes;
+- the party contains six entries;
+- the storage layout contains 14 boxes of 30 `BoxPokemon` entries.
+
+The reference party address `0x03004360` is recorded only as diagnostic metadata
+and is sourced from the [Generation III data-structure reference](https://bulbapedia.bulbagarden.net/wiki/Pok%C3%A9mon_data_structure_in_the_GBA).
+The address is not exposed as a write target and must be confirmed by an AXVD
+fixture before live polling is promoted to `Supported`.
+
+The adapter seam is `IRomCompatibilityAdapter`. A future edition adds another
+adapter/profile instead of extending a Ruby-specific CRC or address switch.


### PR DESCRIPTION
Ticket: https://github.com/mpiechot/PokemonSoulLinkDiscord/issues/72

## Summary
- recognize German Pokémon Ruby AXVD from stable ROM header identity instead of CRC32
- add an extensible ROM compatibility adapter seam and diagnostic-only memory layout metadata
- document Gen III party structure references and the fixture gate for live polling
- keep RAM writes and unverified live reads out of scope

## Verification
- dotnet test PokeSoulLinkBot.Tests/PokeSoulLinkBot.Tests.csproj --no-restore --verbosity minimal
- git diff --cached --check